### PR TITLE
docs: fix install command to use correct crate name

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ That's it. One command. Know what breaks before you break it.
 
 ```bash
 # Install
-cargo install arbor
+cargo install arbor-graph-cli
 
 # Run on any project
 cd your-project

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -5,7 +5,7 @@ Get AI-ready code context in 5 minutes.
 ## Install
 
 ```bash
-cargo install arbor
+cargo install arbor-graph-cli
 ```
 
 ## Initialize


### PR DESCRIPTION
## Summary
- Fix install command in README.md and QUICKSTART.md
- Change `cargo install arbor` to `cargo install arbor-graph-cli`

## Why
The current documentation says `cargo install arbor`, but this fails because:

1. **`arbor` on crates.io is an unrelated project** — a Monte Carlo Tree Search library by a different author
2. **It has no binary** — `cargo install arbor` fails outright since there's nothing to install

The correct crate name is `arbor-graph-cli`, which installs the `arbor` binary.

Note: The individual crate READMEs (in `crates/*/README.md`) already use the correct command.