### PR TITLE
chore: sync Cargo.toml versions to match 1.3.0 release

### DIFF
--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/Anandb71/arbor"

--- a/crates/arbor-cli/Cargo.toml
+++ b/crates/arbor-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "arbor-graph-cli"
-version = "1.0.2"
+version = "1.3.0"
 edition.workspace = true
 license.workspace = true
 description = "Command-line interface for Arbor"


### PR DESCRIPTION
## Summary
Sync Cargo.toml versions to match the 1.3.0 release tag.

| File | Before | After |
|------|--------|-------|
| crates/Cargo.toml (workspace) | 1.0.1 | 1.3.0 |
| crates/arbor-cli/Cargo.toml | 1.0.2 | 1.3.0 |

## Why
Currently `cargo install arbor-graph-cli` from crates.io installs stale code because the crate version (1.0.2) doesn't match the release (1.3.0).

After merging, please run `cargo publish` to update crates.io.