### PR TITLE
Fix init/setup to use nearest workspace root

### DIFF
--- a/crates/arbor-cli/src/commands.rs
+++ b/crates/arbor-cli/src/commands.rs
@@ -45,13 +45,13 @@ fn find_workspace_root(start: &Path) -> PathBuf {
         }
     }
 
-    let mut best = current.clone();
+    let fallback = current.clone();
     loop {
         if ROOT_MARKERS
             .iter()
             .any(|marker| current.join(marker).exists())
         {
-            best = current.clone();
+            return current;
         }
 
         match current.parent() {
@@ -60,7 +60,7 @@ fn find_workspace_root(start: &Path) -> PathBuf {
         }
     }
 
-    best
+    fallback
 }
 
 fn resolve_project_path(path: &Path) -> Result<PathBuf> {

--- a/crates/arbor-cli/tests/init_command_integration.rs
+++ b/crates/arbor-cli/tests/init_command_integration.rs
@@ -1,0 +1,43 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run_arbor(repo: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_arbor"))
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("failed to run arbor")
+}
+
+#[test]
+fn init_uses_nearest_workspace_root() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let home = temp.path().join("home");
+    fs::create_dir_all(home.join(".git")).expect("create home .git");
+
+    let project = home.join("project");
+    fs::create_dir_all(&project).expect("create project dir");
+    fs::write(
+        project.join("Cargo.toml"),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write Cargo.toml");
+
+    let output = run_arbor(&project, &["init", "."]);
+    assert!(
+        output.status.success(),
+        "arbor init failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        project.join(".arbor").exists(),
+        "expected .arbor to be created in the project directory"
+    );
+    assert!(
+        !home.join(".arbor").exists(),
+        "expected .arbor to NOT be created in the parent directory"
+    );
+}


### PR DESCRIPTION
## Summary
- Resolve project path to the nearest workspace marker instead of the highest ancestor
- Add integration coverage for `arbor init .` in nested workspaces

## Testing
- cargo test --workspace

Fixes #142