### PR TITLE
feat: CLI/MCP parity, map command, and concurrency fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ v1_release_checklist.md
 HANDOFF_FOR_NEW_LAPTOP.md
 /package-lock.json
 /arbor-logo.png
+.updates/
 
 # MCP Publisher (never commit)
 .mcpregistry_*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,14 +68,18 @@ arbor-core  →  arbor-graph  →  arbor-watcher
 
 **`arbor-server`** — Tokio WebSocket server on `ws://localhost:7432`. JSON-RPC methods: `discover`, `impact`, `context`, `graph.subscribe`, `spotlight`. RwLock-protected shared graph state.
 
-**`arbor-mcp`** — MCP stdio bridge for AI agents. Ten tools in two tiers:
-- **Surgical** (v2.1.0): `list_entry_points`, `get_callers`, `get_callees`, `search_symbols`, `get_file_graph`, `get_node_detail`
-- **Broad** (existing): `get_logic_path`, `get_knowledge_path`, `find_path`, `analyze_impact`
+**`arbor-mcp`** — MCP stdio bridge for AI agents. Eleven tools in three tiers:
+- **Orientation**: `get_map` — ranked, token-budgeted skeleton of the codebase (recommended first call)
+- **Surgical**: `list_entry_points`, `get_callers`, `get_callees`, `search_symbols`, `get_file_graph`, `get_node_detail`
+- **Broad**: `get_logic_path`, `get_knowledge_path`, `find_path`, `analyze_impact`
 
-All new tools emit a standard JSON envelope: `{ok, tool, arbor_version, data, meta: {node_count, suggested_next_tool, suggested_next_args}}`. Error responses use `{ok: false, error}`. Run via `arbor bridge`.
+All tools emit a standard JSON envelope: `{ok, tool, arbor_version, data, meta: {node_count, suggested_next_tool, suggested_next_args}}`. Error responses use `{ok: false, error}`. Run via `arbor bridge`.
 
-**`arbor-cli`** — Clap CLI with ~20 subcommands. All command logic lives in `src/commands.rs`. Entry point: `src/main.rs`. Dispatches to the other crates. Binary name: `arbor` (crate name: `arbor-graph-cli`).
+**`arbor-cli`** — Clap CLI with ~25 subcommands. All command logic lives in `src/commands.rs`. Entry point: `src/main.rs`. Dispatches to the other crates. Binary name: `arbor` (crate name: `arbor-graph-cli`).
 Key features:
+- `map . --exclude-test`: ranked, token-budgeted project skeleton (PageRank + entry point detection). Supports `--tokens N`, `--focus "pattern"`, `--focus-changed`, `--json`, `--verbose`.
+- `callers`/`callees`/`entry-points`/`file-graph`/`inspect`/`path`: graph query commands matching MCP tools.
+- `query "term1|term2" . --exclude-test`: multi-term OR search with test file filtering.
 - `diff . --markdown`: formats impact analysis report as color-coded Markdown.
 - `check . --markdown`: executes safety threshold validation and prints Markdown PASS/FAIL status.
 - `summary .`: auto-generates structured Pull Request descriptions based on graph diff analysis.
@@ -98,14 +102,114 @@ Key features:
 - **No dotted method calls in JS/TS**: `obj.method()` calls are excluded from edges (requires type inference we don't have); only bare `foo()` and `this./super.` calls are recorded.
 - **Stack overflow prevention**: `stacker::maybe_grow` wraps recursive AST traversal in all parsers; `collect_calls` uses iterative `TreeCursor` to avoid deep call stacks.
 - **Import nodes excluded from graph**: Import/import-from AST nodes are processed for import map data but never added as vertices (prevents false centrality).
+- **Centrality persistence**: `arbor map` computes PageRank on first call and saves it to the binary cache. Subsequent calls skip recomputation (~0.5s vs ~1.5s).
+- **Atomic cache writes**: `save_graph_binary`/`save_graph_snapshot` write to `.tmp` then atomically rename, preventing concurrent processes from reading half-written caches.
+- **Sled lock avoidance**: CLI commands skip the sled store path if `cache/db` exists (implies a bridge may hold the exclusive lock). Falls back to re-indexing from source.
+- **Whitespace-only diff filtering**: `git_changed_files()` cross-references `--name-status` against `--numstat` to exclude files with only whitespace changes.
 
 ### `.arbor/` Directory
 
-Local cache created by `arbor init`/`arbor setup`. Contains `config.json` with default settings. Treated as workspace root marker alongside `.git`, `Cargo.toml`, `package.json`, `go.mod`, `pyproject.toml`.
+Local cache created by `arbor init`/`arbor setup`. Contains `config.json` with default settings, `graph.bin` (bincode-serialized graph with centrality scores), and `graph.json` (JSON snapshot). Treated as workspace root marker alongside `.git`, `Cargo.toml`, `package.json`, `go.mod`, `pyproject.toml`.
+
+## CLI Command Reference
+
+| Command | Purpose |
+|---|---|
+| `setup .` | One-shot init + index |
+| `init .` | Initialize `.arbor/` config |
+| `index .` | Parse and build graph |
+| `map . --exclude-test` | Ranked project skeleton (token-budgeted) |
+| `query "name" .` | Fuzzy symbol search (supports `\|` for OR) |
+| `callers "sym" .` | Who calls this? |
+| `callees "sym" .` | What does this call? |
+| `entry-points .` | HTTP handlers, main, jobs, webhooks |
+| `file-graph "path" .` | Symbols + edges in one file |
+| `inspect "sym" .` | Full symbol detail |
+| `path "a" "b" .` | Shortest call-graph path |
+| `diff .` | Blast radius of git changes |
+| `check .` | CI safety threshold check |
+| `refactor "sym" .` | Blast radius of changing a symbol |
+| `summary .` | Auto-generate PR description |
+| `bridge .` | Start MCP stdio server |
+| `serve .` | Start WebSocket server |
+| `watch .` | File watcher + auto re-index |
+
+All query commands support `--json`. `map` additionally supports `--tokens N`, `--focus "pattern"`, `--focus-changed`, `--verbose`.
+
+## Agent Integration (Claude Code)
+
+To integrate arbor into a target project for AI agent use:
+
+### 1. MCP server (`.mcp.json` at project root)
+
+```json
+{
+  "mcpServers": {
+    "arbor": {
+      "command": "/Users/<you>/.cargo/bin/arbor",
+      "args": ["bridge", "/absolute/path/to/project"]
+    }
+  }
+}
+```
+
+### 2. Hooks (`.claude/settings.json`)
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$CLAUDE_TOOL_INPUT\" | grep -q '\\barbor\\b' && [ ! -d .arbor ] && arbor init . >/dev/null 2>&1; exit 0"
+          },
+          {
+            "type": "command",
+            "command": "echo \"$CLAUDE_TOOL_INPUT\" | grep -qE '(grep|rg)\\s+(-[a-zA-Z]*r|-[a-zA-Z]*R|--recursive)' && echo 'BLOCK: Use arbor instead of recursive grep.' && exit 1; exit 0"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FLAG=\".arbor/.map-injected-$(date +%Y%m%d)\"; [ -f \"$FLAG\" ] && exit 0; touch \"$FLAG\"; echo '--- arbor map (project skeleton) ---'; arbor map . --exclude-test 2>/dev/null; echo '--- end arbor map ---'; exit 0"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**What these do:**
+- **PreToolUse #1**: Auto-initializes `.arbor/` if an arbor command is called but the project isn't set up yet.
+- **PreToolUse #2**: Blocks recursive grep/ripgrep and tells the agent to use arbor instead.
+- **PostToolUse**: Injects `arbor map` output (project skeleton) on the first Bash call each day. Flag file is per-project (`.arbor/.map-injected-<date>`), so each project triggers independently.
+
+### 3. Permissions (`.claude/settings.local.json`)
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(arbor *)"]
+  }
+}
+```
+
+### 4. Agent instructions (`CLAUDE.md` at project root)
+
+Document the workflow: map is auto-injected, use `arbor query`/`callers`/`callees`/`file-graph` for navigation, only `Read` after arbor identifies the target file+line.
 
 ## Active Development Areas
 
-- `v2.0` branch: current development branch
+- `cli-enhancements` branch: map command, CLI parity with MCP, concurrency fixes
 - `arborv2/` — Tauri v2 desktop companion (in progress, excluded from workspace)
 - `lattice/` — Lattice Personal OS integration (excluded from workspace)
 - `extensions/arbor-vscode/` — VS Code extension (separate npm project)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,7 @@ dependencies = [
  "clap",
  "colored",
  "dirs",
+ "fs2",
  "indicatif",
  "petgraph",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,76 +20,93 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.12.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a4b14f3d99c1255dcba8f45621ab1a2e7540a0009652d33989005a4d0bfc6b"
+checksum = "d3d3b8f9bae46a948369bc4a03e815d4ed6d616bd00de4051133a5019dc31c5a"
+
+[[package]]
+name = "accesskit_atspi_common"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5dd55e6e94949498698daf4d48fb5659e824d7abec0d394089656ceaf99d4f"
 dependencies = [
- "enumn",
+ "accesskit",
+ "accesskit_consumer",
+ "atspi-common",
  "serde",
+ "thiserror 1.0.69",
+ "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.16.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c17cca53c09fbd7288667b22a201274b9becaa27f0b91bf52a526db95de45e6"
+checksum = "f47983a1084940ba9a39c077a8c63e55c619388be5476ac04c804cfbd1e63459"
 dependencies = [
  "accesskit",
+ "hashbrown 0.15.5",
+ "immutable-chunkmap",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.10.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3b6ae1eabbfbced10e840fd3fce8a93ae84f174b3e4ba892ab7bcb42e477a7"
+checksum = "7329821f3bd1101e03a7d2e03bd339e3ac0dc64c70b4c9f9ae1949e3ba8dece1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "objc2 0.3.0-beta.3.patch-leaks.3",
- "once_cell",
+ "hashbrown 0.15.5",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
 name = "accesskit_unix"
-version = "0.6.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f46c18d99ba61ad7123dd13eeb0c104436ab6af1df6a1cd8c11054ed394a08"
+checksum = "fcee751cc20d88678c33edaf9c07e8b693cd02819fe89053776f5313492273f5"
 dependencies = [
  "accesskit",
- "accesskit_consumer",
+ "accesskit_atspi_common",
  "async-channel",
- "async-once-cell",
+ "async-executor",
+ "async-task",
  "atspi",
- "futures-lite 1.13.0",
- "once_cell",
+ "futures-lite",
+ "futures-util",
  "serde",
  "zbus",
 ]
 
 [[package]]
 name = "accesskit_windows"
-version = "0.15.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcae27ec0974fc7c3b0b318783be89fd1b2e66dd702179fe600166a38ff4a0b"
+checksum = "24fcd5d23d70670992b823e735e859374d694a3d12bfd8dd32bd3bd8bedb5d81"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "once_cell",
+ "hashbrown 0.15.5",
  "paste",
  "static_assertions",
- "windows 0.48.0",
+ "windows",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.16.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5284218aca17d9e150164428a0ebc7b955f70e3a9a78b4c20894513aabf98a67"
+checksum = "6a6a48dad5530b6deb9fc7a52cc6c3bf72cdd9eb8157ac9d32d69f2427a5e879"
 dependencies = [
  "accesskit",
  "accesskit_macos",
  "accesskit_unix",
  "accesskit_windows",
+ "raw-window-handle",
  "winit",
 ]
 
@@ -108,7 +125,6 @@ dependencies = [
  "cfg-if",
  "getrandom 0.3.4",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
@@ -142,23 +158,21 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
  "bitflags 2.11.0",
  "cc",
- "cesu8",
- "jni 0.21.1",
- "jni-sys 0.3.0",
+ "jni",
  "libc",
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -409,7 +423,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -441,21 +455,23 @@ dependencies = [
 
 [[package]]
 name = "ash"
-version = "0.37.3+1.3.251"
+version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading 0.7.4",
+ "libloading",
 ]
 
 [[package]]
 name = "async-broadcast"
-version = "0.5.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 2.5.3",
+ "event-listener",
+ "event-listener-strategy",
  "futures-core",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -478,42 +494,21 @@ checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.3.0",
- "futures-lite 2.6.1",
+ "fastrand",
+ "futures-lite",
  "pin-project-lite",
  "slab",
 ]
 
 [[package]]
 name = "async-fs"
-version = "1.6.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
 dependencies = [
- "async-lock 2.8.0",
- "autocfg",
+ "async-lock",
  "blocking",
- "futures-lite 1.13.0",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock 2.8.0",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite 1.13.0",
- "log",
- "parking",
- "polling 2.8.0",
- "rustix 0.37.28",
- "slab",
- "socket2 0.4.10",
- "waker-fn",
+ "futures-lite",
 ]
 
 [[package]]
@@ -526,21 +521,12 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.6.1",
+ "futures-lite",
  "parking",
- "polling 3.11.0",
+ "polling",
  "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -549,32 +535,27 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
 
 [[package]]
-name = "async-once-cell"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
 name = "async-process"
-version = "1.8.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
 dependencies = [
- "async-io 1.13.0",
- "async-lock 2.8.0",
+ "async-channel",
+ "async-io",
+ "async-lock",
  "async-signal",
+ "async-task",
  "blocking",
  "cfg-if",
- "event-listener 3.1.0",
- "futures-lite 1.13.0",
- "rustix 0.38.44",
- "windows-sys 0.48.0",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -585,7 +566,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -594,8 +575,8 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
 dependencies = [
- "async-io 2.6.0",
- "async-lock 3.4.2",
+ "async-io",
+ "async-lock",
  "atomic-waker",
  "cfg-if",
  "futures-core",
@@ -620,7 +601,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -631,9 +612,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atspi"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6059f350ab6f593ea00727b334265c4dfc7fd442ee32d264794bd9bdc68e87ca"
+checksum = "be534b16650e35237bb1ed189ba2aab86ce65e88cc84c66f4935ba38575cecbf"
 dependencies = [
  "atspi-common",
  "atspi-connection",
@@ -642,39 +623,42 @@ dependencies = [
 
 [[package]]
 name = "atspi-common"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92af95f966d2431f962bc632c2e68eda7777330158bf640c4af4249349b2cdf5"
+checksum = "1909ed2dc01d0a17505d89311d192518507e8a056a48148e3598fef5e7bb6ba7"
 dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
  "zbus",
+ "zbus-lockstep",
+ "zbus-lockstep-macros",
  "zbus_names",
  "zvariant",
 ]
 
 [[package]]
 name = "atspi-connection"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c65e7d70f86d4c0e3b2d585d9bf3f979f0b19d635a336725a88d279f76b939"
+checksum = "430c5960624a4baaa511c9c0fcc2218e3b58f5dbcc47e6190cafee344b873333"
 dependencies = [
  "atspi-common",
  "atspi-proxies",
- "futures-lite 1.13.0",
+ "futures-lite",
  "zbus",
 ]
 
 [[package]]
 name = "atspi-proxies"
-version = "0.3.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6495661273703e7a229356dcbe8c8f38223d697aacfaf0e13590a9ac9977bb52"
+checksum = "a5e6c5de3e524cf967569722446bcd458d5032348554d9a17d7d72b041ab7496"
 dependencies = [
  "atspi-common",
  "serde",
  "zbus",
+ "zvariant",
 ]
 
 [[package]]
@@ -753,7 +737,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -761,6 +754,12 @@ name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit_field"
@@ -779,6 +778,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitstream-io"
@@ -805,44 +807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-sys"
-version = "0.1.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa55741ee90902547802152aaf3f8e5248aab7e21468089560d4c8840561146"
-dependencies = [
- "objc-sys 0.2.0-beta.2",
-]
-
-[[package]]
-name = "block-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
-dependencies = [
- "objc-sys 0.3.5",
-]
-
-[[package]]
-name = "block2"
-version = "0.2.0-alpha.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
-dependencies = [
- "block-sys 0.1.0-beta.1",
- "objc2-encode 2.0.0-pre.2",
-]
-
-[[package]]
-name = "block2"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
-dependencies = [
- "block-sys 0.2.1",
- "objc2 0.4.1",
-]
-
-[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,7 +824,7 @@ dependencies = [
  "async-channel",
  "async-task",
  "futures-io",
- "futures-lite 2.6.1",
+ "futures-lite",
  "piper",
 ]
 
@@ -904,7 +868,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -927,13 +891,13 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calloop"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
  "bitflags 2.11.0",
  "log",
- "polling 3.11.0",
+ "polling",
  "rustix 0.38.44",
  "slab",
  "thiserror 1.0.69",
@@ -946,7 +910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
 dependencies = [
  "bitflags 2.11.0",
- "polling 3.11.0",
+ "polling",
  "rustix 1.1.4",
  "slab",
  "tracing",
@@ -954,11 +918,11 @@ dependencies = [
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
- "calloop 0.12.4",
+ "calloop 0.13.0",
  "rustix 0.38.44",
  "wayland-backend",
  "wayland-client",
@@ -989,12 +953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,9 +960,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgl"
@@ -1059,7 +1017,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1107,37 +1065,6 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1327,17 +1254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,7 +1308,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1401,7 +1317,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.8.9",
+ "libloading",
 ]
 
 [[package]]
@@ -1420,21 +1336,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "ecolor"
-version = "0.28.1"
+name = "dpi"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6b451ff1143f6de0f33fc7f1b68fecfd2c7de06e104de96c4514de3f5396f8"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
+
+[[package]]
+name = "ecolor"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
  "emath",
- "serde",
 ]
 
 [[package]]
 name = "eframe"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6490ef800b2e41ee129b1f32f9ac15f713233fe3bc18e241a1afe1e4fb6811e0"
+checksum = "d0dfe0859f3fb1bc6424c57d41e10e9093fe938f426b691e42272c2f336d915c"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1454,37 +1375,39 @@ dependencies = [
  "objc2-foundation 0.2.2",
  "parking_lot 0.12.5",
  "percent-encoding",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.2",
+ "profiling",
+ "raw-window-handle",
  "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "web-time 0.2.4",
+ "web-time",
  "winapi",
+ "windows-sys 0.59.0",
  "winit",
 ]
 
 [[package]]
 name = "egui"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20c97e70a2768de630f161bb5392cbd3874fcf72868f14df0e002e82e06cb798"
+checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
 dependencies = [
  "accesskit",
  "ahash",
+ "bitflags 2.11.0",
  "emath",
  "epaint",
  "log",
  "nohash-hasher",
- "serde",
+ "profiling",
 ]
 
 [[package]]
 name = "egui-wgpu"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c7a7c707877c3362a321ebb4f32be811c0b91f7aebf345fb162405c0218b4c"
+checksum = "d319dfef570f699b6e9114e235e862a2ddcf75f0d1a061de9e1328d92146d820"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -1492,36 +1415,39 @@ dependencies = [
  "egui",
  "epaint",
  "log",
+ "profiling",
  "thiserror 1.0.69",
  "type-map",
- "web-time 0.2.4",
+ "web-time",
  "wgpu",
  "winit",
 ]
 
 [[package]]
 name = "egui-winit"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4e066af341bf92559f60dbdf2020b2a03c963415349af5f3f8d79ff7a4926"
+checksum = "7d9dfbb78fe4eb9c3a39ad528b90ee5915c252e77bbab9d4ebc576541ab67e13"
 dependencies = [
  "accesskit_winit",
  "ahash",
  "arboard",
+ "bytemuck",
  "egui",
  "log",
- "raw-window-handle 0.6.2",
+ "profiling",
+ "raw-window-handle",
  "smithay-clipboard",
- "web-time 0.2.4",
+ "web-time",
  "webbrowser",
  "winit",
 ]
 
 [[package]]
 name = "egui_extras"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb783d9fa348f69ed5c340aa25af78b5472043090e8b809040e30960cc2a746"
+checksum = "624659a2e972a46f4d5f646557906c55f1cd5a0836eddbe610fdf1afba1b4226"
 dependencies = [
  "ahash",
  "egui",
@@ -1530,22 +1456,23 @@ dependencies = [
  "image",
  "log",
  "mime_guess2",
+ "profiling",
  "resvg 0.37.0",
- "serde",
 ]
 
 [[package]]
 name = "egui_glow"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2bdc8b38cfa17cc712c4ae079e30c71c00cd4c2763c9e16dc7860a02769103"
+checksum = "910906e3f042ea6d2378ec12a6fd07698e14ddae68aed2d819ffe944a73aab9e"
 dependencies = [
  "ahash",
  "bytemuck",
  "egui",
  "glow",
  "log",
- "memoffset 0.9.1",
+ "memoffset",
+ "profiling",
  "wasm-bindgen",
  "web-sys",
  "winit",
@@ -1573,12 +1500,11 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
+checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
- "serde",
 ]
 
 [[package]]
@@ -1586,6 +1512,12 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
 
 [[package]]
 name = "enum-map"
@@ -1605,7 +1537,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1626,36 +1558,32 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "enumn"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "epaint"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f0dcc0a0771e7500e94cd1cb797bd13c9f23b9409bdc3c824e2cbc562b7fa01"
+checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
 dependencies = [
  "ab_glyph",
  "ahash",
  "bytemuck",
  "ecolor",
  "emath",
+ "epaint_default_fonts",
  "log",
  "nohash-hasher",
  "parking_lot 0.12.5",
- "serde",
+ "profiling",
 ]
+
+[[package]]
+name = "epaint_default_fonts"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
 name = "equator"
@@ -1674,7 +1602,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1710,23 +1638,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
@@ -1742,7 +1653,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener",
  "pin-project-lite",
 ]
 
@@ -1767,17 +1678,8 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
 dependencies = [
- "bit-set",
+ "bit-set 0.5.3",
  "regex",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -1803,7 +1705,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1901,7 +1803,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1952,26 +1854,11 @@ checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -1986,7 +1873,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2128,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "glow"
-version = "0.13.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -2140,55 +2027,56 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.31.3"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
  "bitflags 2.11.0",
  "cfg_aliases",
  "cgl",
- "core-foundation 0.9.4",
- "dispatch",
+ "dispatch2",
  "glutin_egl_sys",
  "glutin_glx_sys",
  "glutin_wgl_sys",
- "icrate",
- "libloading 0.8.9",
- "objc2 0.4.1",
+ "libloading",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
- "raw-window-handle 0.5.2",
+ "raw-window-handle",
  "wayland-sys",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
  "x11-dl",
 ]
 
 [[package]]
 name = "glutin-winit"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebcdfba24f73b8412c5181e56f092b5eff16671c514ce896b258a0a64bd7735"
+checksum = "85edca7075f8fc728f28cb8fbb111a96c3b89e930574369e3e9c27eb75d3788f"
 dependencies = [
  "cfg_aliases",
  "glutin",
- "raw-window-handle 0.5.2",
+ "raw-window-handle",
  "winit",
 ]
 
 [[package]]
 name = "glutin_egl_sys"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77cc5623f5309ef433c3dd4ca1223195347fe62c413da8e2fdd0eb76db2d9bcd"
+checksum = "4c4680ba6195f424febdc3ba46e7a42a0e58743f2edb115297b86d7f8ecc02d2"
 dependencies = [
  "gl_generator",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "glutin_glx_sys"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a165fd686c10dcc2d45380b35796e577eacfd43d4660ee741ec8ebe2201b3b4f"
+checksum = "8a7bb2938045a88b612499fbcba375a77198e01306f52272e692f8c1f3751185"
 dependencies = [
  "gl_generator",
  "x11-dl",
@@ -2196,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "glutin_wgl_sys"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
 dependencies = [
  "gl_generator",
 ]
@@ -2220,19 +2108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
  "bitflags 2.11.0",
-]
-
-[[package]]
-name = "gpu-allocator"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
-dependencies = [
- "log",
- "presser",
- "thiserror 1.0.69",
- "winapi",
- "windows 0.52.0",
 ]
 
 [[package]]
@@ -2282,31 +2157,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
-name = "hassle-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
-dependencies = [
- "bitflags 2.11.0",
- "com",
- "libc",
- "libloading 0.8.9",
- "thiserror 1.0.69",
- "widestring",
- "winapi",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -2364,17 +2218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icrate"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d3aaff8a54577104bafdf686ff18565c3b6903ca5782a2026ef06e2c7aa319"
-dependencies = [
- "block2 0.3.0",
- "dispatch",
- "objc2 0.4.1",
 ]
 
 [[package]]
@@ -2564,6 +2407,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
+name = "immutable-chunkmap"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3e98b1520e49e252237edc238a39869da9f3241f2ec19dc788c1d24694d1e4"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2585,7 +2437,7 @@ dependencies = [
  "number_prefix",
  "portable-atomic",
  "unicode-width 0.2.2",
- "web-time 1.1.0",
+ "web-time",
 ]
 
 [[package]]
@@ -2625,18 +2477,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
- "windows-sys 0.48.0",
+ "syn",
 ]
 
 [[package]]
@@ -2659,22 +2500,6 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.0",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
 
 [[package]]
 name = "jni"
@@ -2703,7 +2528,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2728,7 +2553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2758,7 +2583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.8.9",
+ "libloading",
  "pkg-config",
 ]
 
@@ -2844,16 +2669,6 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
@@ -2879,12 +2694,6 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.3",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2979,15 +2788,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -2997,9 +2797,9 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.28.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
 dependencies = [
  "bitflags 2.11.0",
  "block",
@@ -3073,38 +2873,38 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.20.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
+checksum = "e380993072e52eef724eddfcde0ed013b0c023c3f0417336ed041aa9f076994e"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.11.0",
+ "cfg_aliases",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
  "log",
- "num-traits",
  "rustc-hash 1.1.0",
  "spirv",
+ "strum",
  "termcolor",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "unicode-xid",
 ]
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.11.0",
  "jni-sys 0.3.0",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "thiserror 1.0.69",
 ]
 
@@ -3124,6 +2924,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-sys"
+version = "0.6.0+11769913"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
+dependencies = [
+ "jni-sys 0.3.0",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,14 +2940,15 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "cfg-if",
+ "cfg_aliases",
  "libc",
- "memoffset 0.7.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -3219,7 +3029,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3267,10 +3077,10 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3290,36 +3100,9 @@ dependencies = [
 
 [[package]]
 name = "objc-sys"
-version = "0.2.0-beta.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
-
-[[package]]
-name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
-
-[[package]]
-name = "objc2"
-version = "0.3.0-beta.3.patch-leaks.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e01640f9f2cb1220bbe80325e179e532cb3379ebcd1bf2279d703c19fe3a468"
-dependencies = [
- "block2 0.2.0-alpha.6",
- "objc-sys 0.2.0-beta.2",
- "objc2-encode 2.0.0-pre.2",
-]
-
-[[package]]
-name = "objc2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
-dependencies = [
- "objc-sys 0.3.5",
- "objc2-encode 3.0.0",
-]
 
 [[package]]
 name = "objc2"
@@ -3327,8 +3110,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
 dependencies = [
- "objc-sys 0.3.5",
- "objc2-encode 4.1.0",
+ "objc-sys",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -3337,7 +3120,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
- "objc2-encode 4.1.0",
+ "objc2-encode",
 ]
 
 [[package]]
@@ -3347,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.5.1",
+ "block2",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
@@ -3364,8 +3147,33 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "objc2 0.6.4",
+ "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-contacts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
+dependencies = [
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3375,7 +3183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -3410,26 +3218,23 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
 ]
 
 [[package]]
-name = "objc2-encode"
-version = "2.0.0-pre.2"
+name = "objc2-core-location"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abfcac41015b00a120608fdaa6938c44cb983fee294351cc4bac7638b4e50512"
+checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "objc-sys 0.2.0-beta.2",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-contacts",
+ "objc2-foundation 0.2.2",
 ]
-
-[[package]]
-name = "objc2-encode"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
 name = "objc2-encode"
@@ -3444,7 +3249,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.5.1",
+ "block2",
+ "dispatch",
  "libc",
  "objc2 0.5.2",
 ]
@@ -3472,13 +3278,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-link-presentation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
+dependencies = [
+ "block2",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
 name = "objc2-metal"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -3490,10 +3308,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.11.0",
- "block2 0.5.1",
+ "block2",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-symbols"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
+dependencies = [
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
+ "objc2-link-presentation",
+ "objc2-quartz-core",
+ "objc2-symbols",
+ "objc2-uniform-type-identifiers",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-uniform-type-identifiers"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
+dependencies = [
+ "block2",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
+dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "objc2 0.5.2",
+ "objc2-core-location",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -3531,6 +3404,15 @@ checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
 dependencies = [
  "libc",
  "libredox",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3666,7 +3548,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "unicase",
 ]
 
@@ -3687,6 +3569,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,7 +3601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand 2.3.0",
+ "fastrand",
  "futures-io",
 ]
 
@@ -3743,29 +3645,13 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.2",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -3796,29 +3682,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "presser"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "syn",
 ]
 
 [[package]]
@@ -3827,7 +3697,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.5+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3855,7 +3725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3888,6 +3758,16 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff6510e86862b57b210fd8cbe8ed3f0d7d600b9c2863cd4549a2e033c66e956"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quick-xml"
@@ -4030,12 +3910,6 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
-name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
@@ -4077,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
 ]
@@ -4237,20 +4111,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
@@ -4357,14 +4217,14 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b31447ca297092c5a9916fc3b955203157b37c19ca8edde4f52e9843e602c7"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
  "ab_glyph",
  "log",
  "memmap2",
- "smithay-client-toolkit 0.18.1",
+ "smithay-client-toolkit 0.19.2",
  "tiny-skia",
 ]
 
@@ -4401,7 +4261,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4425,7 +4285,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4555,13 +4415,13 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
  "bitflags 2.11.0",
- "calloop 0.12.4",
- "calloop-wayland-source 0.2.0",
+ "calloop 0.13.0",
+ "calloop-wayland-source 0.3.0",
  "cursor-icon",
  "libc",
  "log",
@@ -4572,8 +4432,8 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.31.2",
- "wayland-protocols-wlr 0.2.0",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
 ]
@@ -4597,10 +4457,10 @@ dependencies = [
  "wayland-client",
  "wayland-csd-frame",
  "wayland-cursor",
- "wayland-protocols 0.32.11",
+ "wayland-protocols",
  "wayland-protocols-experimental",
  "wayland-protocols-misc",
- "wayland-protocols-wlr 0.3.11",
+ "wayland-protocols-wlr",
  "wayland-scanner",
  "xkeysym",
 ]
@@ -4623,16 +4483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -4695,6 +4545,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4722,17 +4594,6 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -4750,7 +4611,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4759,7 +4620,7 @@ version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
@@ -4801,7 +4662,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4812,7 +4673,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4916,7 +4777,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4929,7 +4790,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -4946,12 +4807,6 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-
-[[package]]
-name = "toml_datetime"
 version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
@@ -4961,25 +4816,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap",
- "toml_datetime 1.0.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
@@ -4988,7 +4832,7 @@ version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow 1.0.0",
+ "winnow",
 ]
 
 [[package]]
@@ -5011,7 +4855,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -5208,7 +5052,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -5443,12 +5287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5528,7 +5366,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -5625,18 +5463,6 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
-dependencies = [
- "bitflags 2.11.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols"
 version = "0.32.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
@@ -5656,7 +5482,7 @@ dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.11",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -5669,33 +5495,20 @@ dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.11",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.2.0"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+checksum = "d392fc283a87774afc9beefcd6f931582bb97fe0e6ced0b306a62cb1d026527c"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
-dependencies = [
- "bitflags 2.11.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -5708,7 +5521,7 @@ dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.32.11",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -5719,7 +5532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.39.2",
  "quote",
 ]
 
@@ -5747,16 +5560,6 @@ dependencies = [
 
 [[package]]
 name = "web-time"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
@@ -5772,7 +5575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
 dependencies = [
  "core-foundation 0.10.1",
- "jni 0.22.4",
+ "jni",
  "log",
  "ndk-context",
  "objc2 0.6.4",
@@ -5807,19 +5610,19 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "wgpu"
-version = "0.20.1"
+version = "24.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e37c7b9921b75dfd26dd973fdcbce36f13dfa6e2dc82aece584e0ed48c355c"
+checksum = "6b0b3436f0729f6cdf2e6e9201f3d39dc95813fad61d826c1ed07918b4539353"
 dependencies = [
  "arrayvec",
- "cfg-if",
+ "bitflags 2.11.0",
  "cfg_aliases",
  "document-features",
  "js-sys",
  "log",
  "parking_lot 0.12.5",
  "profiling",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "smallvec",
  "static_assertions",
  "wasm-bindgen",
@@ -5832,15 +5635,14 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.21.1"
+version = "24.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
+checksum = "7f0aa306497a238d169b9dc70659105b4a096859a34894544ca81719242e1499"
 dependencies = [
  "arrayvec",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "cfg_aliases",
- "codespan-reporting",
  "document-features",
  "indexmap",
  "log",
@@ -5848,72 +5650,66 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.5",
  "profiling",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
- "web-sys",
+ "thiserror 2.0.18",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "0.21.1"
+version = "24.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
+checksum = "f112f464674ca69f3533248508ee30cb84c67cf06c25ff6800685f5e0294e259"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bitflags 2.11.0",
+ "bytemuck",
  "cfg_aliases",
  "core-graphics-types",
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
- "gpu-allocator",
  "gpu-descriptor",
- "hassle-rs",
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.9",
+ "libloading",
  "log",
  "metal",
  "naga",
- "ndk-sys",
+ "ndk-sys 0.5.0+25.2.9519653",
  "objc",
  "once_cell",
+ "ordered-float",
  "parking_lot 0.12.5",
  "profiling",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "winapi",
+ "windows",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "0.20.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
+checksum = "50ac044c0e76c03a0378e7786ac505d010a873665e2d51383dcff8dd227dc69c"
 dependencies = [
  "bitflags 2.11.0",
  "js-sys",
+ "log",
  "web-sys",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -5948,31 +5744,24 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.48.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-implement 0.48.0",
- "windows-interface 0.48.0",
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5985,19 +5774,19 @@ dependencies = [
  "windows-implement 0.60.2",
  "windows-interface 0.59.3",
  "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.48.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2ee588991b9e7e6c8338edf3333fbe4da35dc72092643958ebb43f0ab2c49c"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -6008,18 +5797,18 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.48.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6fb8df20c9bcaa8ad6ab513f7b40104840c8867d5751126e4df3b08388d0cc7"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -6030,7 +5819,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6038,6 +5827,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-result"
@@ -6050,20 +5848,21 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -6109,21 +5908,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6176,12 +5960,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6200,12 +5978,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6221,12 +5993,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6260,12 +6026,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6281,12 +6041,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6308,12 +6062,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6329,12 +6077,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6356,60 +6098,54 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winit"
-version = "0.29.15"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d59ad965a635657faf09c8f062badd885748428933dad8e8bdd64064d92e5ca"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
  "bitflags 2.11.0",
+ "block2",
  "bytemuck",
- "calloop 0.12.4",
+ "calloop 0.13.0",
  "cfg_aliases",
+ "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics",
  "cursor-icon",
- "icrate",
+ "dpi",
  "js-sys",
  "libc",
- "log",
  "memmap2",
  "ndk",
- "ndk-sys",
- "objc2 0.4.1",
- "once_cell",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
- "raw-window-handle 0.5.2",
- "raw-window-handle 0.6.2",
- "redox_syscall 0.3.5",
+ "pin-project",
+ "raw-window-handle",
+ "redox_syscall 0.4.1",
  "rustix 0.38.44",
  "sctk-adwaita",
- "smithay-client-toolkit 0.18.1",
+ "smithay-client-toolkit 0.19.2",
  "smol_str",
+ "tracing",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-protocols-plasma",
  "web-sys",
- "web-time 0.2.4",
- "windows-sys 0.48.0",
+ "web-time",
+ "windows-sys 0.52.0",
  "x11-dl",
  "x11rb",
  "xkbcommon-dl",
-]
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -6451,7 +6187,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -6467,7 +6203,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -6535,7 +6271,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading 0.8.9",
+ "libloading",
  "once_cell",
  "rustix 1.1.4",
  "x11rb-protocol",
@@ -6619,36 +6355,33 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "3.15.2"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
 dependencies = [
  "async-broadcast",
  "async-executor",
  "async-fs",
- "async-io 1.13.0",
- "async-lock 2.8.0",
+ "async-io",
+ "async-lock",
  "async-process",
  "async-recursion",
  "async-task",
  "async-trait",
  "blocking",
- "byteorder",
- "derivative",
  "enumflags2",
- "event-listener 2.5.3",
+ "event-listener",
  "futures-core",
  "futures-sink",
  "futures-util",
  "hex",
  "nix",
- "once_cell",
  "ordered-stream",
  "rand 0.8.5",
  "serde",
@@ -6657,7 +6390,7 @@ dependencies = [
  "static_assertions",
  "tracing",
  "uds_windows",
- "winapi",
+ "windows-sys 0.52.0",
  "xdg-home",
  "zbus_macros",
  "zbus_names",
@@ -6665,27 +6398,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "zbus_macros"
-version = "3.15.2"
+name = "zbus-lockstep"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7131497b0f887e8061b430c530240063d33bf9455fa34438f388a245da69e0a5"
+checksum = "4ca2c5dceb099bddaade154055c926bb8ae507a18756ba1d8963fd7b51d8ed1d"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-lockstep-macros"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709ab20fc57cb22af85be7b360239563209258430bccf38d8b979c5a2ae3ecce"
+dependencies = [
  "proc-macro2",
  "quote",
- "regex",
- "syn 1.0.109",
+ "syn",
+ "zbus-lockstep",
+ "zbus_xml",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "2.6.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437d738d3750bed6ca9b8d423ccc7a8eb284f6b1d6d4e225a0e4e6258d864c8d"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
 dependencies = [
  "serde",
  "static_assertions",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_xml"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f374552b954f6abb4bd6ce979e6c9b38fb9d0cd7cc68a7d796e70c9f3a233"
+dependencies = [
+ "quick-xml 0.30.0",
+ "serde",
+ "static_assertions",
+ "zbus_names",
  "zvariant",
 ]
 
@@ -6706,7 +6475,7 @@ checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6726,7 +6495,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -6766,7 +6535,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -6816,13 +6585,12 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "3.15.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eef2be88ba09b358d3b58aca6e41cd853631d44787f319a1383ca83424fb2db"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
 dependencies = [
- "byteorder",
+ "endi",
  "enumflags2",
- "libc",
  "serde",
  "static_assertions",
  "zvariant_derive",
@@ -6830,24 +6598,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "3.15.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c24dc0bed72f5f90d1f8bb5b07228cbf63b3c6e9f82d82559d4bae666e7ed9"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7234f0d811589db492d16893e3f21e8e2fd282e6d01b0cddee310322062cc200"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]

--- a/action.yml
+++ b/action.yml
@@ -52,15 +52,35 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        ARBOR_AUTO_INDEX: "1"
       run: |
         set -euo pipefail
         cd "${{ inputs.working-directory }}"
         
-        # 1. Run the normal user-supplied command
+        # 1. Set environment variables for pull requests to specify diff range
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          export ARBOR_DIFF_BASE="$PR_BASE_SHA"
+          export ARBOR_DIFF_HEAD="$PR_HEAD_SHA"
+          echo "PR environment detected. Range set: $ARBOR_DIFF_BASE ... $ARBOR_DIFF_HEAD"
+          
+          # Ensure base and head SHAs are fetched and accessible locally for git diff
+          if ! git rev-parse --verify "$ARBOR_DIFF_BASE" >/dev/null 2>&1; then
+            echo "Fetching base SHA: $ARBOR_DIFF_BASE"
+            git fetch --depth=100 origin "$ARBOR_DIFF_BASE" || git fetch origin "$ARBOR_DIFF_BASE" || true
+          fi
+          if ! git rev-parse --verify "$ARBOR_DIFF_HEAD" >/dev/null 2>&1; then
+            echo "Fetching head SHA: $ARBOR_DIFF_HEAD"
+            git fetch --depth=100 origin "$ARBOR_DIFF_HEAD" || git fetch origin "$ARBOR_DIFF_HEAD" || true
+          fi
+        fi
+
+        # 2. Run the normal user-supplied command
         echo "Running: arbor ${{ inputs.command }}"
         arbor ${{ inputs.command }}
         
-        # 2. Check if we should post a PR comment
+        # 3. Check if we should post a PR comment
         if [[ "${{ inputs.comment-on-pr }}" == "true" && "${{ github.event_name }}" == "pull_request" ]]; then
           echo "Generating Arbor Impact Report for PR comment..."
           

--- a/crates/arbor-cli/Cargo.toml
+++ b/crates/arbor-cli/Cargo.toml
@@ -31,6 +31,7 @@ strsim = "0.11"
 petgraph = "0.6"
 anyhow = "1.0"
 bincode = "1.3"
+fs2 = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/arbor-cli/src/commands.rs
+++ b/crates/arbor-cli/src/commands.rs
@@ -73,7 +73,60 @@ fn resolve_project_path(path: &Path) -> Result<PathBuf> {
     Ok(find_workspace_root(&base))
 }
 
+/// Whether Arbor may index a project that has no `.arbor/` directory yet.
+///
+/// Off by default so commands run against an un-indexed project (e.g. a
+/// different repo) don't silently create a `.arbor/` and write a cache into it.
+/// Resolution order: `ARBOR_AUTO_INDEX` env var, then `auto_index` in the
+/// global config (`~/.arbor/config.json`), then `false`.
+fn auto_index_enabled() -> bool {
+    if let Ok(val) = std::env::var("ARBOR_AUTO_INDEX") {
+        return matches!(val.trim().to_lowercase().as_str(), "1" | "true" | "yes" | "on");
+    }
+    global_config_auto_index().unwrap_or(false)
+}
+
+/// Reads `auto_index` from the global config at `~/.arbor/config.json`.
+fn global_config_auto_index() -> Option<bool> {
+    let config_path = dirs::home_dir()?.join(".arbor").join("config.json");
+    let text = fs::read_to_string(config_path).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&text).ok()?;
+    json.get("auto_index").and_then(|v| v.as_bool())
+}
+
+/// Returns true if `path` has already been indexed (has a `.arbor/` directory).
+fn project_is_indexed(path: &Path) -> bool {
+    path.join(".arbor").exists()
+}
+
+/// Error returned when a command needs an indexed project but the project is
+/// un-indexed and auto-indexing is disabled.
+fn not_indexed_error(path: &Path) -> Box<dyn std::error::Error> {
+    format!(
+        "Project at {} is not indexed and auto-indexing is disabled.\n  \
+         Run 'arbor index {}' to index it, or enable auto-indexing with \
+         ARBOR_AUTO_INDEX=1 (or \"auto_index\": true in ~/.arbor/config.json).",
+        path.display(),
+        path.display()
+    )
+    .into()
+}
+
+/// Ensures `.arbor/` exists for an *implicit* (non-`index`/`init`) command.
+///
+/// If the project is already indexed, this is a no-op create. If it is NOT
+/// indexed, it only creates `.arbor/` when auto-indexing is enabled; otherwise
+/// it errors rather than mutating the project.
 fn ensure_arbor_initialized(path: &Path) -> Result<bool> {
+    if !project_is_indexed(path) && !auto_index_enabled() {
+        return Err(not_indexed_error(path));
+    }
+    init_arbor_dir(path)
+}
+
+/// Creates and populates `.arbor/` unconditionally. Used by the explicit
+/// `init`/`index`/`setup` commands, which always opt the user into indexing.
+fn init_arbor_dir(path: &Path) -> Result<bool> {
     let arbor_dir = path.join(".arbor");
     let config_path = arbor_dir.join("config.json");
 
@@ -221,6 +274,14 @@ fn cache_is_stale(path: &Path) -> bool {
 }
 
 fn load_or_index_graph(path: &Path) -> Result<arbor_graph::ArborGraph> {
+    // Refuse to index an un-indexed project unless auto-indexing is enabled —
+    // this is the choke point for read commands that don't call
+    // ensure_arbor_initialized first, and prevents writing a cache into a
+    // project the user never opted in to.
+    if !project_is_indexed(path) && !auto_index_enabled() {
+        return Err(not_indexed_error(path));
+    }
+
     // When a bridge is running it keeps graph.bin fresh via its own persister —
     // skip the staleness check to avoid a redundant re-index that races with
     // the bridge's writes.
@@ -841,7 +902,7 @@ pub fn init(path: &Path) -> Result<()> {
         return Ok(());
     }
 
-    let _ = ensure_arbor_initialized(&resolved_path)?;
+    let _ = init_arbor_dir(&resolved_path)?;
 
     println!(
         "{} Initialized Arbor in {}",
@@ -862,7 +923,7 @@ pub fn index(
     changed_only: bool,
 ) -> Result<()> {
     let resolved_path = resolve_project_path(path)?;
-    let was_initialized = ensure_arbor_initialized(&resolved_path)?;
+    let was_initialized = init_arbor_dir(&resolved_path)?;
     if was_initialized {
         println!(
             "{} Created {} for first-time setup",

--- a/crates/arbor-cli/src/commands.rs
+++ b/crates/arbor-cli/src/commands.rs
@@ -1,7 +1,7 @@
 //! CLI command implementations.
 
 use arbor_core::parse_file;
-use arbor_graph::compute_centrality;
+use arbor_graph::{compute_centrality, HeuristicsMatcher};
 use arbor_server::{ArborServer, ServerConfig};
 use arbor_watcher::{index_directory, IndexOptions};
 use colored::Colorize;
@@ -123,9 +123,11 @@ fn save_graph_snapshot(path: &Path, graph: &arbor_graph::ArborGraph) -> Result<(
         fs::create_dir_all(parent)?;
     }
 
-    let file = std::fs::File::create(&graph_path)?;
+    let tmp_path = graph_path.with_extension("json.tmp");
+    let file = std::fs::File::create(&tmp_path)?;
     let writer = std::io::BufWriter::new(file);
     serde_json::to_writer_pretty(writer, graph)?;
+    fs::rename(&tmp_path, &graph_path)?;
     Ok(())
 }
 
@@ -135,8 +137,10 @@ fn save_graph_binary(path: &Path, graph: &arbor_graph::ArborGraph) -> Result<()>
         fs::create_dir_all(parent)?;
     }
 
+    let tmp_path = graph_path.with_extension("bin.tmp");
     let bytes = bincode::serialize(graph)?;
-    fs::write(graph_path, bytes)?;
+    fs::write(&tmp_path, bytes)?;
+    fs::rename(&tmp_path, &graph_path)?;
     Ok(())
 }
 
@@ -153,7 +157,8 @@ fn load_graph_snapshot(path: &Path) -> Result<arbor_graph::ArborGraph> {
 
     let file = std::fs::File::open(&graph_path)?;
     let reader = std::io::BufReader::new(file);
-    let graph: arbor_graph::ArborGraph = serde_json::from_reader(reader)?;
+    let mut graph: arbor_graph::ArborGraph = serde_json::from_reader(reader)?;
+    graph.rebuild_search_index();
     Ok(graph)
 }
 
@@ -164,7 +169,8 @@ fn load_graph_binary(path: &Path) -> Result<arbor_graph::ArborGraph> {
     }
 
     let bytes = fs::read(graph_path)?;
-    let graph: arbor_graph::ArborGraph = bincode::deserialize(&bytes)?;
+    let mut graph: arbor_graph::ArborGraph = bincode::deserialize(&bytes)?;
+    graph.rebuild_search_index();
     Ok(graph)
 }
 
@@ -177,7 +183,7 @@ fn load_graph_from_store(path: &Path) -> Result<arbor_graph::ArborGraph> {
     let store = arbor_graph::GraphStore::open_or_reset(&store_path)
         .map_err(|e| format!("Failed to open graph store: {}", e))?;
 
-    let graph = store
+    let mut graph = store
         .load_graph()
         .map_err(|e| format!("Failed to load graph from store: {}", e))?;
 
@@ -185,6 +191,7 @@ fn load_graph_from_store(path: &Path) -> Result<arbor_graph::ArborGraph> {
         return Err("Graph store was empty".into());
     }
 
+    graph.rebuild_search_index();
     Ok(graph)
 }
 
@@ -197,11 +204,20 @@ fn load_or_index_graph(path: &Path) -> Result<arbor_graph::ArborGraph> {
         return Ok(graph);
     }
 
-    if let Ok(graph) = load_graph_from_store(path) {
-        // Materialize JSON snapshot for faster future warm starts.
-        let _ = save_graph_snapshot(path, &graph);
-        let _ = save_graph_binary(path, &graph);
-        return Ok(graph);
+    // Only try sled store if no snapshot files exist AND no bridge/server
+    // could be holding a lock. Sled locks are exclusive — a running bridge
+    // will cause CLI calls to block indefinitely.
+    let store_path = graph_store_path(path);
+    let has_snapshot_files =
+        graph_binary_path(path).exists() || graph_snapshot_path(path).exists();
+    let bridge_may_be_running = store_path.join("db").exists();
+
+    if !has_snapshot_files && !bridge_may_be_running {
+        if let Ok(graph) = load_graph_from_store(path) {
+            let _ = save_graph_snapshot(path, &graph);
+            let _ = save_graph_binary(path, &graph);
+            return Ok(graph);
+        }
     }
 
     let result = index_directory(path, IndexOptions::default())?;
@@ -276,6 +292,25 @@ fn is_generated_or_internal_path(path: &str) -> bool {
             .any(|suffix| normalized.ends_with(suffix))
 }
 
+fn parse_numstat_files(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .filter_map(|line| {
+            let parts: Vec<&str> = line.split('\t').collect();
+            if parts.len() < 3 {
+                return None;
+            }
+            let path = if parts[2].contains(" => ") || !parts[2].is_empty() {
+                parts[2]
+            } else {
+                parts.get(2).copied().unwrap_or("")
+            };
+            let normalized = normalize_slashes(path.trim());
+            if normalized.is_empty() { None } else { Some(normalized) }
+        })
+        .collect()
+}
+
 fn git_changed_files(path: &Path) -> Result<Vec<String>> {
     if !is_git_repo(path) {
         return Ok(Vec::new());
@@ -295,6 +330,15 @@ fn git_changed_files(path: &Path) -> Result<Vec<String>> {
             )?;
 
             let mut files = parse_git_name_status_output(&ranged);
+
+            let numstat = run_git(
+                path,
+                &["diff", "-w", "--numstat", "--find-renames", base, head],
+            )?;
+            let has_real_diff: std::collections::HashSet<String> =
+                parse_numstat_files(&numstat).into_iter().collect();
+            files.retain(|f| has_real_diff.contains(f));
+
             files.retain(|path| !is_generated_or_internal_path(path));
             files.sort();
             files.dedup();
@@ -323,6 +367,20 @@ fn git_changed_files(path: &Path) -> Result<Vec<String>> {
         ],
     )?;
     files.extend(parse_git_name_status_output(&staged));
+
+    let numstat_unstaged = run_git(
+        path,
+        &["diff", "-w", "--numstat", "--find-renames", "HEAD"],
+    )?;
+    let numstat_staged = run_git(
+        path,
+        &["diff", "--cached", "-w", "--numstat", "--find-renames", "HEAD"],
+    )?;
+    let has_real_diff: std::collections::HashSet<String> = parse_numstat_files(&numstat_unstaged)
+        .into_iter()
+        .chain(parse_numstat_files(&numstat_staged))
+        .collect();
+    files.retain(|f| has_real_diff.contains(f));
 
     let untracked = run_git(path, &["ls-files", "--others", "--exclude-standard"])?;
     files.extend(
@@ -955,15 +1013,75 @@ fn export_graph(graph: &arbor_graph::ArborGraph, path: &Path) -> Result<()> {
     Ok(())
 }
 
-pub fn query(query: &str, limit: usize, path: &Path) -> Result<()> {
+fn is_test_file(file_path: &str) -> bool {
+    let lower = file_path.to_lowercase();
+    let segments: Vec<&str> = lower.split('/').collect();
+    let filename = segments.last().copied().unwrap_or("");
+
+    segments.iter().any(|s| {
+        *s == "test"
+            || *s == "tests"
+            || *s == "spec"
+            || *s == "specs"
+            || *s == "fixture"
+            || *s == "fixtures"
+            || *s == "mock"
+            || *s == "mocks"
+            || *s == "__tests__"
+            || *s == "__mocks__"
+            || *s == "testfixtures"
+    }) || lower.ends_with("test.java")
+        || lower.ends_with("tests.java")
+        || lower.ends_with("test.rs")
+        || lower.ends_with("test.ts")
+        || lower.ends_with("test.tsx")
+        || lower.ends_with("test.js")
+        || lower.ends_with("test.jsx")
+        || lower.ends_with("test.py")
+        || lower.ends_with("test.go")
+        || lower.ends_with("_test.go")
+        || lower.ends_with("tests.cs")
+        || lower.ends_with("test.cs")
+        || lower.ends_with("_test.dart")
+        || lower.contains(".spec.")
+        || lower.contains(".test.")
+        || filename.starts_with("test_")
+        || filename == "conftest.py"
+}
+
+pub fn query(query: &str, limit: usize, path: &Path, exclude_test: bool) -> Result<()> {
     let resolved_path = resolve_project_path(path)?;
     let _ = ensure_arbor_initialized(&resolved_path)?;
     let graph = load_or_index_graph(&resolved_path)?;
 
-    let matches: Vec<_> = graph.search(query).into_iter().take(limit).collect();
+    let terms: Vec<&str> = query.split('|').map(str::trim).filter(|s| !s.is_empty()).collect();
+
+    let mut seen_ids = std::collections::HashSet::new();
+    let mut matches = Vec::new();
+
+    for term in &terms {
+        for node in graph.search(term) {
+            if exclude_test && is_test_file(&node.file) {
+                continue;
+            }
+            if seen_ids.insert(&node.id) {
+                matches.push(node);
+            }
+            if matches.len() >= limit {
+                break;
+            }
+        }
+        if matches.len() >= limit {
+            break;
+        }
+    }
 
     if matches.is_empty() {
-        println!("No matches found for \"{}\"", query);
+        if exclude_test {
+            println!("No matches found for \"{}\" (excluding test files)", query);
+        } else {
+            println!("No matches found for \"{}\"", query);
+        }
         return Ok(());
     }
 
@@ -2908,6 +3026,362 @@ pub fn audit(sink: &str, depth: usize, format: &str, path: &Path) -> Result<()> 
         "arbor audit".bold(),
         sink
     );
+
+    Ok(())
+}
+
+fn resolve_symbol(graph: &arbor_graph::ArborGraph, symbol: &str) -> Result<arbor_graph::NodeId> {
+    graph
+        .get_index(symbol)
+        .or_else(|| {
+            graph
+                .find_by_name(symbol)
+                .first()
+                .and_then(|n| graph.get_index(&n.id))
+        })
+        .ok_or_else(|| format!("Symbol '{}' not found", symbol).into())
+}
+
+pub fn callers(symbol: &str, path: &Path, json_output: bool) -> Result<()> {
+    let resolved_path = resolve_project_path(path)?;
+    let graph = load_or_index_graph(&resolved_path)?;
+
+    let idx = resolve_symbol(&graph, symbol)?;
+    let callers = graph.get_callers(idx);
+
+    if json_output {
+        let items: Vec<serde_json::Value> = callers
+            .iter()
+            .map(|n| {
+                serde_json::json!({
+                    "id": n.id,
+                    "name": n.name,
+                    "kind": n.kind.to_string(),
+                    "file": n.file,
+                    "line": n.line_start
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "symbol": symbol,
+                "callers": items
+            }))?
+        );
+    } else if callers.is_empty() {
+        println!("No callers found for '{}'", symbol);
+    } else {
+        println!("Callers of '{}' ({}):\n", symbol, callers.len());
+        for n in &callers {
+            println!(
+                "  {} {} {}",
+                n.kind.to_string().yellow(),
+                n.qualified_name.cyan(),
+                format!("({}:{})", n.file, n.line_start).dimmed()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub fn callees(symbol: &str, path: &Path, json_output: bool) -> Result<()> {
+    let resolved_path = resolve_project_path(path)?;
+    let graph = load_or_index_graph(&resolved_path)?;
+
+    let idx = resolve_symbol(&graph, symbol)?;
+    let callees = graph.get_callees(idx);
+
+    if json_output {
+        let items: Vec<serde_json::Value> = callees
+            .iter()
+            .map(|n| {
+                serde_json::json!({
+                    "id": n.id,
+                    "name": n.name,
+                    "kind": n.kind.to_string(),
+                    "file": n.file,
+                    "line": n.line_start
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "symbol": symbol,
+                "callees": items
+            }))?
+        );
+    } else if callees.is_empty() {
+        println!("No callees found for '{}'", symbol);
+    } else {
+        println!("Callees of '{}' ({}):\n", symbol, callees.len());
+        for n in &callees {
+            println!(
+                "  {} {} {}",
+                n.kind.to_string().yellow(),
+                n.qualified_name.cyan(),
+                format!("({}:{})", n.file, n.line_start).dimmed()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub fn entry_points(path: &Path, json_output: bool) -> Result<()> {
+    let resolved_path = resolve_project_path(path)?;
+    let graph = load_or_index_graph(&resolved_path)?;
+
+    let eps = graph.list_entry_points();
+
+    if json_output {
+        let items: Vec<serde_json::Value> = eps
+            .iter()
+            .map(|n| {
+                serde_json::json!({
+                    "id": n.id,
+                    "name": n.name,
+                    "kind": n.kind.to_string(),
+                    "file": n.file,
+                    "line": n.line_start
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "entry_points": items
+            }))?
+        );
+    } else if eps.is_empty() {
+        println!("No entry points detected.");
+    } else {
+        println!("Entry points ({}):\n", eps.len());
+        for n in &eps {
+            println!(
+                "  {} {} {}",
+                n.kind.to_string().yellow(),
+                n.qualified_name.cyan(),
+                format!("({}:{})", n.file, n.line_start).dimmed()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+pub fn file_graph(file: &str, path: &Path, json_output: bool) -> Result<()> {
+    let resolved_path = resolve_project_path(path)?;
+    let graph = load_or_index_graph(&resolved_path)?;
+
+    let candidates = [
+        file.to_string(),
+        file.replace('\\', "/"),
+        resolved_path.join(file).to_string_lossy().to_string(),
+        resolved_path
+            .join(file.replace('\\', "/"))
+            .to_string_lossy()
+            .to_string(),
+    ];
+
+    for candidate in &candidates {
+        let (nodes, edges) = graph.nodes_in_file_with_edges(candidate);
+        if !nodes.is_empty() {
+            return print_file_graph_output(candidate, &nodes, &edges, json_output);
+        }
+    }
+
+    Err(format!("No symbols found in file '{}'", file).into())
+}
+
+fn print_file_graph_output(
+    file: &str,
+    nodes: &[&arbor_core::CodeNode],
+    edges: &[(String, String, String)],
+    json_output: bool,
+) -> Result<()> {
+    if json_output {
+        let node_items: Vec<serde_json::Value> = nodes
+            .iter()
+            .map(|n| {
+                serde_json::json!({
+                    "id": n.id,
+                    "name": n.name,
+                    "kind": n.kind.to_string(),
+                    "line": n.line_start
+                })
+            })
+            .collect();
+        let edge_items: Vec<serde_json::Value> = edges
+            .iter()
+            .map(|(from, to, kind)| {
+                serde_json::json!({
+                    "from": from,
+                    "to": to,
+                    "kind": kind
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "file": file,
+                "nodes": node_items,
+                "edges": edge_items
+            }))?
+        );
+    } else {
+        println!("Symbols in '{}' ({}):\n", file, nodes.len());
+        for n in nodes {
+            println!(
+                "  {} {} {}",
+                n.kind.to_string().yellow(),
+                n.qualified_name.cyan(),
+                format!("(L{}–{})", n.line_start, n.line_end).dimmed()
+            );
+        }
+        if !edges.is_empty() {
+            println!("\nInternal edges ({}):\n", edges.len());
+            for (from, to, kind) in edges {
+                println!("  {} {} {}", from.cyan(), "→".dimmed(), format!("{} ({})", to, kind).dimmed());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn inspect(symbol: &str, path: &Path, json_output: bool) -> Result<()> {
+    let resolved_path = resolve_project_path(path)?;
+    let graph = load_or_index_graph(&resolved_path)?;
+
+    let idx = resolve_symbol(&graph, symbol)?;
+    let node = graph
+        .get(idx)
+        .ok_or_else(|| format!("Node index invalid for '{}'", symbol))?;
+    let centrality = graph.centrality(idx);
+    let callers = graph.get_callers(idx);
+    let callees = graph.get_callees(idx);
+    let is_entry = HeuristicsMatcher::is_likely_entry_point(node);
+    let role = if is_entry {
+        "entry_point"
+    } else if callers.is_empty() {
+        "unreachable"
+    } else if callees.is_empty() {
+        "utility"
+    } else {
+        "internal"
+    };
+
+    if json_output {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "id": node.id,
+                "name": node.name,
+                "kind": node.kind.to_string(),
+                "file": node.file,
+                "line_start": node.line_start,
+                "line_end": node.line_end,
+                "signature": node.signature,
+                "centrality": centrality,
+                "role": role,
+                "caller_count": callers.len(),
+                "callee_count": callees.len(),
+                "is_entry_point": is_entry
+            }))?
+        );
+    } else {
+        println!("  {}:    {}", "Name".bold(), node.name);
+        println!("  {}:    {}", "Kind".bold(), node.kind.to_string().yellow());
+        println!(
+            "  {}:    {}:{}-{}",
+            "File".bold(),
+            node.file,
+            node.line_start,
+            node.line_end
+        );
+        if let Some(ref sig) = node.signature {
+            println!("  {}:     {}", "Sig".bold(), sig.dimmed());
+        }
+        println!("  {}:    {}", "Role".bold(), role.cyan());
+        println!("  {}:     {:.4}", "Rank".bold(), centrality);
+        println!("  {}:  {}", "Callers".bold(), callers.len());
+        println!("  {}:  {}", "Callees".bold(), callees.len());
+    }
+
+    Ok(())
+}
+
+pub fn find_path_cmd(start: &str, end: &str, path: &Path, json_output: bool) -> Result<()> {
+    let resolved_path = resolve_project_path(path)?;
+    let graph = load_or_index_graph(&resolved_path)?;
+
+    let start_idx = resolve_symbol(&graph, start)?;
+    let end_idx = resolve_symbol(&graph, end)?;
+
+    let found = graph.find_path(start_idx, end_idx);
+
+    if json_output {
+        match &found {
+            Some(nodes) => {
+                let items: Vec<serde_json::Value> = nodes
+                    .iter()
+                    .map(|n| {
+                        serde_json::json!({
+                            "id": n.id,
+                            "name": n.name,
+                            "kind": n.kind.to_string(),
+                            "file": n.file,
+                            "line": n.line_start
+                        })
+                    })
+                    .collect();
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "start": start,
+                        "end": end,
+                        "path": items,
+                        "hops": items.len().saturating_sub(1)
+                    }))?
+                );
+            }
+            None => {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "start": start,
+                        "end": end,
+                        "path": null,
+                        "message": "No path found"
+                    }))?
+                );
+            }
+        }
+    } else {
+        match &found {
+            Some(nodes) => {
+                println!("Path ({} hops):\n", nodes.len().saturating_sub(1));
+                for (i, n) in nodes.iter().enumerate() {
+                    if i > 0 {
+                        println!("    {}", "↓".dimmed());
+                    }
+                    println!(
+                        "  {} {} {}",
+                        n.kind.to_string().yellow(),
+                        n.qualified_name.cyan(),
+                        format!("({}:{})", n.file, n.line_start).dimmed()
+                    );
+                }
+            }
+            None => {
+                println!("No path found between '{}' and '{}'", start, end);
+            }
+        }
+    }
 
     Ok(())
 }

--- a/crates/arbor-cli/src/commands.rs
+++ b/crates/arbor-cli/src/commands.rs
@@ -208,8 +208,7 @@ fn load_or_index_graph(path: &Path) -> Result<arbor_graph::ArborGraph> {
     // could be holding a lock. Sled locks are exclusive — a running bridge
     // will cause CLI calls to block indefinitely.
     let store_path = graph_store_path(path);
-    let has_snapshot_files =
-        graph_binary_path(path).exists() || graph_snapshot_path(path).exists();
+    let has_snapshot_files = graph_binary_path(path).exists() || graph_snapshot_path(path).exists();
     let bridge_may_be_running = store_path.join("db").exists();
 
     if !has_snapshot_files && !bridge_may_be_running {
@@ -306,7 +305,11 @@ fn parse_numstat_files(output: &str) -> Vec<String> {
                 parts.get(2).copied().unwrap_or("")
             };
             let normalized = normalize_slashes(path.trim());
-            if normalized.is_empty() { None } else { Some(normalized) }
+            if normalized.is_empty() {
+                None
+            } else {
+                Some(normalized)
+            }
         })
         .collect()
 }
@@ -368,13 +371,17 @@ fn git_changed_files(path: &Path) -> Result<Vec<String>> {
     )?;
     files.extend(parse_git_name_status_output(&staged));
 
-    let numstat_unstaged = run_git(
-        path,
-        &["diff", "-w", "--numstat", "--find-renames", "HEAD"],
-    )?;
+    let numstat_unstaged = run_git(path, &["diff", "-w", "--numstat", "--find-renames", "HEAD"])?;
     let numstat_staged = run_git(
         path,
-        &["diff", "--cached", "-w", "--numstat", "--find-renames", "HEAD"],
+        &[
+            "diff",
+            "--cached",
+            "-w",
+            "--numstat",
+            "--find-renames",
+            "HEAD",
+        ],
     )?;
     let has_real_diff: std::collections::HashSet<String> = parse_numstat_files(&numstat_unstaged)
         .into_iter()
@@ -1054,7 +1061,11 @@ pub fn query(query: &str, limit: usize, path: &Path, exclude_test: bool) -> Resu
     let _ = ensure_arbor_initialized(&resolved_path)?;
     let graph = load_or_index_graph(&resolved_path)?;
 
-    let terms: Vec<&str> = query.split('|').map(str::trim).filter(|s| !s.is_empty()).collect();
+    let terms: Vec<&str> = query
+        .split('|')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
 
     let mut seen_ids = std::collections::HashSet::new();
     let mut matches = Vec::new();
@@ -3245,7 +3256,12 @@ fn print_file_graph_output(
         if !edges.is_empty() {
             println!("\nInternal edges ({}):\n", edges.len());
             for (from, to, kind) in edges {
-                println!("  {} {} {}", from.cyan(), "→".dimmed(), format!("{} ({})", to, kind).dimmed());
+                println!(
+                    "  {} {} {}",
+                    from.cyan(),
+                    "→".dimmed(),
+                    format!("{} ({})", to, kind).dimmed()
+                );
             }
         }
     }
@@ -3384,4 +3400,429 @@ pub fn find_path_cmd(start: &str, end: &str, path: &Path, json_output: bool) -> 
     }
 
     Ok(())
+}
+
+pub fn map(
+    path: &Path,
+    token_budget: usize,
+    exclude_test: bool,
+    json_output: bool,
+    verbose: bool,
+    focus_changed: bool,
+    focus_glob: Option<&str>,
+) -> Result<()> {
+    let resolved_path = resolve_project_path(path)?;
+    let _ = ensure_arbor_initialized(&resolved_path)?;
+    let mut graph = load_or_index_graph(&resolved_path)?;
+
+    // Compute centrality if not already present, then persist for future calls
+    let has_centrality = graph.node_indexes().any(|idx| graph.centrality(idx) > 0.0);
+    if !has_centrality {
+        eprintln!("Computing centrality...");
+        let scores = compute_centrality(&graph, 20, 0.85);
+        graph.set_centrality(scores.into_map());
+        let _ = save_graph_binary(&resolved_path, &graph);
+    }
+
+    // Build set of changed files for --focus-changed
+    let changed_files: std::collections::HashSet<String> =
+        if focus_changed && is_git_repo(&resolved_path) {
+            git_changed_files(&resolved_path)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|f| resolved_path.join(&f).to_string_lossy().to_string())
+                .collect()
+        } else {
+            std::collections::HashSet::new()
+        };
+
+    struct ScoredNode {
+        name: String,
+        kind: String,
+        file: String,
+        line_start: u32,
+        line_end: u32,
+        signature: Option<String>,
+        score: f64,
+        is_entry_point: bool,
+        callers: usize,
+    }
+
+    let mut scored: Vec<ScoredNode> = Vec::new();
+    for idx in graph.node_indexes() {
+        let node = match graph.get(idx) {
+            Some(n) => n,
+            None => continue,
+        };
+
+        if exclude_test && is_test_file(&node.file) {
+            continue;
+        }
+
+        // Skip minified/generated files
+        if is_minified_or_generated(&node.file) {
+            continue;
+        }
+
+        let kind_str = node.kind.to_string();
+        if kind_str == "import" || kind_str == "export" || kind_str == "module" {
+            continue;
+        }
+
+        let centrality = graph.centrality(idx);
+        let is_entry = HeuristicsMatcher::is_likely_entry_point(node);
+        let caller_count = graph.get_callers(idx).len();
+
+        let kind_boost = match kind_str.as_str() {
+            "class" | "interface" | "struct" => 0.1,
+            "constructor" => -0.1,
+            "field" | "constant" => -0.2,
+            _ => 0.0,
+        };
+        let entry_boost = if is_entry { 0.3 } else { 0.0 };
+        let changed_boost = if changed_files.contains(&node.file) {
+            0.3
+        } else {
+            0.0
+        };
+        let glob_boost = match focus_glob {
+            Some(pattern) if node.file.contains(pattern.trim_matches('*')) => 0.3,
+            _ => 0.0,
+        };
+        let score = centrality + entry_boost + kind_boost + changed_boost + glob_boost;
+
+        scored.push(ScoredNode {
+            name: node.name.clone(),
+            kind: kind_str,
+            file: node.file.clone(),
+            line_start: node.line_start,
+            line_end: node.line_end,
+            signature: node.signature.clone(),
+            score,
+            is_entry_point: is_entry,
+            callers: caller_count,
+        });
+    }
+
+    scored.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    let total_symbols = scored.len();
+
+    // Group by file, preserving rank order of first appearance.
+    // Cap symbols per file to force breadth across the project.
+    let max_per_file: usize = if token_budget <= 1024 {
+        5
+    } else if token_budget <= 2048 {
+        8
+    } else {
+        12
+    };
+
+    let mut file_order: Vec<String> = Vec::new();
+    let mut file_groups: std::collections::HashMap<String, Vec<&ScoredNode>> =
+        std::collections::HashMap::new();
+    for node in &scored {
+        let group = file_groups.entry(node.file.clone()).or_default();
+        if group.len() >= max_per_file {
+            continue;
+        }
+        if group.is_empty() {
+            file_order.push(node.file.clone());
+        }
+        group.push(node);
+    }
+
+    let root_str = resolved_path.to_string_lossy().to_string();
+    let budget_chars = token_budget * 4;
+
+    if json_output {
+        let mut entries: Vec<serde_json::Value> = Vec::new();
+        let mut json_symbols_shown = 0;
+        let mut json_chars = 0;
+
+        for file_path in &file_order {
+            let symbols = match file_groups.get(file_path) {
+                Some(s) => s,
+                None => continue,
+            };
+
+            let rel_path = map_make_relative(file_path, &root_str);
+            let short_path = map_compress_path(file_path, &root_str);
+
+            let mut sym_items: Vec<serde_json::Value> = Vec::new();
+            for node in symbols {
+                let sig_short = node
+                    .signature
+                    .as_deref()
+                    .map(map_shorten_signature)
+                    .unwrap_or_else(|| node.name.clone());
+
+                let item_cost = sig_short.len() + 50;
+                if json_chars + item_cost > budget_chars && json_symbols_shown > 0 {
+                    break;
+                }
+
+                sym_items.push(serde_json::json!({
+                    "name": node.name,
+                    "kind": node.kind,
+                    "line": node.line_start,
+                    "centrality": (node.score * 100.0).round() / 100.0,
+                    "callers": node.callers,
+                    "is_entry_point": node.is_entry_point,
+                    "signature_short": sig_short,
+                }));
+                json_symbols_shown += 1;
+                json_chars += item_cost;
+            }
+
+            if !sym_items.is_empty() {
+                entries.push(serde_json::json!({
+                    "file": rel_path,
+                    "file_short": short_path,
+                    "symbols": sym_items,
+                }));
+            }
+
+            if json_chars >= budget_chars {
+                break;
+            }
+        }
+
+        let output = serde_json::json!({
+            "schema": "arbor.map.v1",
+            "token_estimate": json_chars / 4,
+            "symbols_shown": json_symbols_shown,
+            "symbols_total": total_symbols,
+            "files_shown": entries.len(),
+            "files_total": file_order.len(),
+            "entries": entries,
+        });
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        let mut output_lines: Vec<String> = Vec::new();
+        let mut token_chars: usize = 0;
+        let mut symbols_shown: usize = 0;
+        let mut files_shown: usize = 0;
+        let mut budget_hit = false;
+
+        for file_path in &file_order {
+            if budget_hit {
+                break;
+            }
+
+            let symbols = match file_groups.get(file_path) {
+                Some(s) => s,
+                None => continue,
+            };
+
+            let display_path = if verbose {
+                map_make_relative(file_path, &root_str)
+            } else {
+                map_compress_path(file_path, &root_str)
+            };
+
+            let header = format!("{}:", display_path);
+            let header_cost = header.len() + 1;
+
+            if token_chars + header_cost > budget_chars && files_shown > 0 {
+                break;
+            }
+
+            output_lines.push(header);
+            token_chars += header_cost;
+            files_shown += 1;
+
+            for node in symbols {
+                let entry_marker = if node.is_entry_point { " ★" } else { "" };
+                let line_info =
+                    if node.kind == "class" || node.kind == "interface" || node.kind == "struct" {
+                        format!("[L{}-{}]", node.line_start, node.line_end)
+                    } else {
+                        format!("L{}", node.line_start)
+                    };
+
+                let line =
+                    if node.kind == "class" || node.kind == "interface" || node.kind == "struct" {
+                        format!(
+                            "  {} {} {}{}",
+                            node.kind, node.name, line_info, entry_marker
+                        )
+                    } else {
+                        let sig_short = node
+                            .signature
+                            .as_deref()
+                            .map(map_shorten_signature)
+                            .unwrap_or_else(|| node.name.clone());
+                        format!("    {}  {}{}", sig_short, line_info, entry_marker)
+                    };
+
+                let line_cost = line.len() + 1;
+                if token_chars + line_cost > budget_chars && symbols_shown > 0 {
+                    let remaining_symbols = total_symbols - symbols_shown;
+                    let remaining_files = file_order.len() - files_shown;
+                    output_lines.push(format!(
+                        "\n⋮... {} more symbols across {} files (use --tokens {} to see more)",
+                        remaining_symbols,
+                        remaining_files,
+                        token_budget * 2
+                    ));
+                    budget_hit = true;
+                    break;
+                }
+
+                output_lines.push(line);
+                token_chars += line_cost;
+                symbols_shown += 1;
+            }
+
+            if !budget_hit {
+                output_lines.push(String::new());
+                token_chars += 1;
+            }
+        }
+
+        println!(
+            "# arbor map ({} symbols, {} files, budget: {} tokens)\n",
+            symbols_shown, files_shown, token_budget,
+        );
+        for line in &output_lines {
+            println!("{}", line);
+        }
+    }
+
+    Ok(())
+}
+
+fn is_minified_or_generated(file_path: &str) -> bool {
+    let lower = file_path.to_lowercase();
+    lower.ends_with(".min.js")
+        || lower.ends_with(".min.css")
+        || lower.contains(".chunk.")
+        || lower.contains(".bundle.")
+        || lower.contains("/dist/")
+        || lower.contains("/build/")
+        || lower.contains("/resources/monitor/")
+        || lower.contains("/resources/static/")
+        || lower.contains("/generated/")
+        // Hashed filenames (e.g. main.d094b1b69ba24b63.js)
+        || {
+            let filename = lower.rsplit('/').next().unwrap_or("");
+            let parts: Vec<&str> = filename.split('.').collect();
+            parts.len() >= 3 && parts[1].len() >= 8 && parts[1].chars().all(|c| c.is_ascii_hexdigit())
+        }
+}
+
+fn map_make_relative(file_path: &str, root: &str) -> String {
+    file_path
+        .strip_prefix(root)
+        .unwrap_or(file_path)
+        .trim_start_matches('/')
+        .to_string()
+}
+
+fn map_compress_path(file_path: &str, root: &str) -> String {
+    let relative = map_make_relative(file_path, root);
+    let parts: Vec<&str> = relative.split('/').collect();
+
+    if parts.len() <= 4 {
+        return relative;
+    }
+
+    let first = parts[0];
+    let filename = parts[parts.len() - 1];
+    let parent = parts[parts.len() - 2];
+    let grandparent = parts[parts.len() - 3];
+
+    format!("{}/.../{}/{}/{}", first, grandparent, parent, filename)
+}
+
+fn map_shorten_signature(sig: &str) -> String {
+    let sig = sig.trim();
+
+    let paren_start = match sig.find('(') {
+        Some(i) => i,
+        None => {
+            if sig.len() <= 80 {
+                return sig.to_string();
+            } else {
+                return format!("{}...", &sig[..77]);
+            }
+        }
+    };
+
+    // Extract name: last word before the opening paren
+    let before_paren = &sig[..paren_start];
+    let name = before_paren
+        .split_whitespace()
+        .last()
+        .unwrap_or(before_paren)
+        .trim();
+
+    let paren_end = match sig.rfind(')') {
+        Some(i) => i,
+        None => return format!("{}(...)", name),
+    };
+
+    let params_str = &sig[paren_start + 1..paren_end];
+    let param_names = map_extract_param_names(params_str);
+
+    let result = if param_names.is_empty() {
+        format!("{}()", name)
+    } else {
+        format!("{}({})", name, param_names.join(", "))
+    };
+
+    if result.len() > 80 {
+        format!("{}(...)", name)
+    } else {
+        result
+    }
+}
+
+fn map_extract_param_names(params_str: &str) -> Vec<&str> {
+    if params_str.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let mut names = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0;
+
+    let bytes = params_str.as_bytes();
+    for i in 0..bytes.len() {
+        match bytes[i] {
+            b'<' | b'(' => depth += 1,
+            b'>' | b')' => depth -= 1,
+            b',' if depth == 0 => {
+                if let Some(name) = map_last_word_of_param(&params_str[start..i]) {
+                    names.push(name);
+                }
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    if let Some(name) = map_last_word_of_param(&params_str[start..]) {
+        names.push(name);
+    }
+
+    names
+}
+
+fn map_last_word_of_param(param: &str) -> Option<&str> {
+    let trimmed = param.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Rust-style: name before the colon
+    if let Some(colon_pos) = trimmed.find(':') {
+        let before_colon = trimmed[..colon_pos].trim();
+        return before_colon.split_whitespace().last();
+    }
+    // Java/TS-style: name is last word
+    trimmed.split_whitespace().last()
 }

--- a/crates/arbor-cli/src/commands.rs
+++ b/crates/arbor-cli/src/commands.rs
@@ -64,7 +64,7 @@ fn find_workspace_root(start: &Path) -> PathBuf {
     fallback
 }
 
-fn resolve_project_path(path: &Path) -> Result<PathBuf> {
+pub(crate) fn resolve_project_path(path: &Path) -> Result<PathBuf> {
     let base = if path == Path::new(".") {
         std::env::current_dir()?
     } else {
@@ -81,7 +81,10 @@ fn resolve_project_path(path: &Path) -> Result<PathBuf> {
 /// global config (`~/.arbor/config.json`), then `false`.
 fn auto_index_enabled() -> bool {
     if let Ok(val) = std::env::var("ARBOR_AUTO_INDEX") {
-        return matches!(val.trim().to_lowercase().as_str(), "1" | "true" | "yes" | "on");
+        return matches!(
+            val.trim().to_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        );
     }
     global_config_auto_index().unwrap_or(false)
 }

--- a/crates/arbor-cli/src/commands.rs
+++ b/crates/arbor-cli/src/commands.rs
@@ -1540,42 +1540,37 @@ pub async fn bridge(path: &Path, launch_viz: bool, follow_symlinks: bool) -> Res
     let graph = arbor_graph::ArborGraph::new();
     let shared_graph = std::sync::Arc::new(tokio::sync::RwLock::new(graph));
 
-    // 2. Run Initial Index (Blocking)
+    // 2. Index in background so MCP stdio starts immediately (prevents client timeout)
     let index_path = resolved_path.to_path_buf();
     let options = IndexOptions {
         follow_symlinks,
         cache_path: Some(resolved_path.join(".arbor").join("cache")),
     };
-    eprintln!("{} Starting initial index...", "⏳".yellow());
+    eprintln!("{} Starting initial index (background)...", "⏳".yellow());
 
-    // Run blocking indexer
-    let result = tokio::task::spawn_blocking(move || index_directory(&index_path, options)).await?;
+    let index_graph = shared_graph.clone();
+    tokio::spawn(async move {
+        let result =
+            tokio::task::spawn_blocking(move || index_directory(&index_path, options)).await;
+        match result {
+            Ok(Ok(index_result)) => {
+                let mut guard = index_graph.write().await;
+                *guard = index_result.graph;
 
-    match result {
-        Ok(index_result) => {
-            let mut guard = shared_graph.write().await;
-            *guard = index_result.graph;
+                let scores = compute_centrality(&guard, 20, 0.85);
+                guard.set_centrality(scores.into_map());
 
-            // Compute centrality
-            let scores = compute_centrality(&guard, 20, 0.85);
-            guard.set_centrality(scores.into_map());
-
-            eprintln!(
-                "{} Index Ready: {} files, {} nodes",
-                "✓".green(),
-                index_result.files_indexed,
-                index_result.nodes_extracted
-            );
+                eprintln!(
+                    "{} Index Ready: {} files, {} nodes",
+                    "✓".green(),
+                    index_result.files_indexed,
+                    index_result.nodes_extracted
+                );
+            }
+            Ok(Err(e)) => eprintln!("{} Indexing failed: {}", "⚠".red(), e),
+            Err(e) => eprintln!("{} Index task panicked: {}", "⚠".red(), e),
         }
-        Err(e) => eprintln!("{} Indexing failed: {}", "⚠".red(), e),
-    }
-
-    // Pass a clone to the background watcher/indexer (which we should start separately if we want continuous updates)
-    // Actually, SyncServer handles the continuous watching!
-    // The previous code had a separate background indexer that seemingly did nothing after the initial index?
-    // No, wait. The previous code ONLY did the initial index.
-    // The SyncServer (lines 355) is what handles *subsequent* file updates via its own watcher.
-    // So this change is strictly correct.
+    });
 
     // 3. Start Servers (Background)
     let rpc_port = 7433;

--- a/crates/arbor-cli/src/commands.rs
+++ b/crates/arbor-cli/src/commands.rs
@@ -183,7 +183,15 @@ fn save_graph_snapshot(path: &Path, graph: &arbor_graph::ArborGraph) -> Result<(
     let file = std::fs::File::create(&tmp_path)?;
     let writer = std::io::BufWriter::new(file);
     serde_json::to_writer_pretty(writer, graph)?;
-    fs::rename(&tmp_path, &graph_path)?;
+    if let Err(e) = fs::rename(&tmp_path, &graph_path) {
+        // `rename` may fail to overwrite an existing destination on some platforms (e.g. Windows).
+        if graph_path.exists() {
+            fs::remove_file(&graph_path)?;
+            fs::rename(&tmp_path, &graph_path)?;
+        } else {
+            return Err(e.into());
+        }
+    }
     Ok(())
 }
 

--- a/crates/arbor-cli/src/commands.rs
+++ b/crates/arbor-cli/src/commands.rs
@@ -195,21 +195,53 @@ fn load_graph_from_store(path: &Path) -> Result<arbor_graph::ArborGraph> {
     Ok(graph)
 }
 
-fn load_or_index_graph(path: &Path) -> Result<arbor_graph::ArborGraph> {
-    if let Ok(graph) = load_graph_binary(path) {
-        return Ok(graph);
-    }
+/// Returns the modified time of a cache file in seconds since the UNIX epoch.
+fn cache_mtime_secs(cache_path: &Path) -> Option<u64> {
+    fs::metadata(cache_path)
+        .and_then(|m| m.modified())
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
 
-    if let Ok(graph) = load_graph_snapshot(path) {
-        return Ok(graph);
+/// Returns true if a source file is newer than the freshest cache file,
+/// meaning the cached graph is stale and should be rebuilt from source.
+fn cache_is_stale(path: &Path) -> bool {
+    // Compare against the freshest of the two cache files — a running bridge's
+    // periodic writer keeps graph.bin current, so prefer whichever is newer.
+    let newest = [graph_binary_path(path), graph_snapshot_path(path)]
+        .iter()
+        .filter_map(|p| cache_mtime_secs(p))
+        .max();
+    match newest {
+        Some(cache_mtime) => arbor_watcher::sources_newer_than(path, cache_mtime, false),
+        None => false, // no cache yet; nothing to call stale
+    }
+}
+
+fn load_or_index_graph(path: &Path) -> Result<arbor_graph::ArborGraph> {
+    // When a bridge is running it keeps graph.bin fresh via its own persister —
+    // skip the staleness check to avoid a redundant re-index that races with
+    // the bridge's writes.
+    let store_path = graph_store_path(path);
+    let bridge_may_be_running = store_path.join("db").exists();
+
+    let stale = !bridge_may_be_running && cache_is_stale(path);
+    if !stale {
+        if let Ok(graph) = load_graph_binary(path) {
+            return Ok(graph);
+        }
+
+        if let Ok(graph) = load_graph_snapshot(path) {
+            return Ok(graph);
+        }
     }
 
     // Only try sled store if no snapshot files exist AND no bridge/server
     // could be holding a lock. Sled locks are exclusive — a running bridge
     // will cause CLI calls to block indefinitely.
-    let store_path = graph_store_path(path);
     let has_snapshot_files = graph_binary_path(path).exists() || graph_snapshot_path(path).exists();
-    let bridge_may_be_running = store_path.join("db").exists();
 
     if !has_snapshot_files && !bridge_may_be_running {
         if let Ok(graph) = load_graph_from_store(path) {
@@ -1619,6 +1651,16 @@ pub async fn bridge(path: &Path, launch_viz: bool, follow_symlinks: bool) -> Res
     let sync_server = arbor_server::SyncServer::new_with_shared(sync_config, shared_graph.clone());
     let spotlight_handle = sync_server.handle();
 
+    // Persist the live graph to disk so cold `arbor map`/`query` reads stay fast
+    // and fresh. The background indexer broadcasts on every patch; we debounce
+    // those into at most one graph.bin write every few seconds.
+    let persist_rx = sync_server.subscribe();
+    let persist_graph = shared_graph.clone();
+    let persist_path = resolved_path.to_path_buf();
+    tokio::spawn(async move {
+        run_graph_persister(persist_rx, persist_graph, persist_path).await;
+    });
+
     tokio::spawn(async move {
         if let Err(e) = arbor_server.run().await {
             eprintln!("RPC Server error: {}", e);
@@ -2691,6 +2733,63 @@ pub fn summary(path: &Path) -> Result<()> {
     println!("*Generated automatically by [Arbor](https://github.com/Anandb71/arbor) v{} — Graph-Native Code Intelligence*", env!("CARGO_PKG_VERSION"));
 
     Ok(())
+}
+
+/// Periodically persists the live graph to `graph.bin` while a bridge runs.
+///
+/// Only one bridge per project wins the persist lock — additional bridges for
+/// the same project skip disk writes (their in-memory graph + MCP are still
+/// fully functional). This prevents multiple bridges from stomping each other.
+async fn run_graph_persister(
+    mut rx: tokio::sync::broadcast::Receiver<arbor_server::BroadcastMessage>,
+    graph: std::sync::Arc<tokio::sync::RwLock<arbor_graph::ArborGraph>>,
+    path: PathBuf,
+) {
+    use arbor_server::BroadcastMessage;
+    use fs2::FileExt;
+    use tokio::sync::broadcast::error::RecvError;
+    use tokio::time::{interval, Duration};
+
+    // Acquire an exclusive advisory lock — only one persister per project.
+    let lock_path = path.join(".arbor").join("persist.lock");
+    let lock_file = match fs::File::create(&lock_path) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+    if lock_file.try_lock_exclusive().is_err() {
+        eprintln!(
+            "{} Another bridge is persisting for this project — skipping disk writes",
+            "ℹ".cyan()
+        );
+        return;
+    }
+
+    const FLUSH_SECS: u64 = 5;
+    let mut dirty = false;
+    let mut tick = interval(Duration::from_secs(FLUSH_SECS));
+
+    loop {
+        tokio::select! {
+            msg = rx.recv() => match msg {
+                Ok(BroadcastMessage::GraphUpdate(_)) => dirty = true,
+                Ok(_) => {}
+                Err(RecvError::Lagged(_)) => dirty = true,
+                Err(RecvError::Closed) => break,
+            },
+            _ = tick.tick() => {
+                if dirty {
+                    let guard = graph.read().await;
+                    if let Err(e) = save_graph_binary(&path, &guard) {
+                        eprintln!("{} Failed to persist graph cache: {}", "⚠".yellow(), e);
+                    }
+                    dirty = false;
+                }
+            }
+        }
+    }
+
+    // Lock released when lock_file drops (process exit or loop break).
+    drop(lock_file);
 }
 
 /// Watch for file changes and re-index automatically.

--- a/crates/arbor-cli/src/commands.rs
+++ b/crates/arbor-cli/src/commands.rs
@@ -1125,7 +1125,7 @@ fn export_graph(graph: &arbor_graph::ArborGraph, path: &Path) -> Result<()> {
 }
 
 fn is_test_file(file_path: &str) -> bool {
-    let lower = file_path.to_lowercase();
+    let lower = file_path.to_lowercase().replace('\\', "/");
     let segments: Vec<&str> = lower.split('/').collect();
     let filename = segments.last().copied().unwrap_or("");
 

--- a/crates/arbor-cli/src/hook/claude.rs
+++ b/crates/arbor-cli/src/hook/claude.rs
@@ -1,0 +1,380 @@
+//! Claude Code harness: CLAUDE.md directives + `.claude/settings.json` hooks +
+//! arbor command permissions.
+
+use super::{Harness, Result, Scope};
+use colored::Colorize;
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Markers wrapping the Arbor block in CLAUDE.md so re-running `arbor hook`
+/// replaces it in place instead of appending a duplicate.
+const BEGIN_MARKER: &str =
+    "<!-- BEGIN arbor-claude-guidance (auto-installed by `arbor hook claude`; remove this block to disable) -->";
+const END_MARKER: &str = "<!-- END arbor-claude-guidance -->";
+
+/// arbor commands allow-listed so the agent runs them without a prompt.
+const PERMISSIONS: &[&str] = &[
+    "Bash(arbor query *)",
+    "Bash(arbor file-graph *)",
+    "Bash(arbor callers *)",
+    "Bash(arbor callees *)",
+    "Bash(arbor map *)",
+    "Bash(arbor path *)",
+    "Bash(arbor inspect *)",
+    "Bash(arbor diff *)",
+    "Bash(arbor entry-points *)",
+    "Bash(arbor refactor *)",
+    "Bash(arbor export *)",
+];
+
+pub struct Claude;
+
+impl Harness for Claude {
+    fn apply(&self, scope: &Scope) -> Result<()> {
+        let root = match scope {
+            Scope::Project(p) => p.clone(),
+            Scope::Global => dirs::home_dir().ok_or("could not resolve home directory")?,
+        };
+
+        apply_directives(&root, scope)?;
+        apply_settings(&root)?;
+
+        println!(
+            "{} Arbor wired into Claude Code at {}",
+            "✓".green(),
+            root.display()
+        );
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CLAUDE.md directives
+// ---------------------------------------------------------------------------
+
+/// Locate the CLAUDE.md to edit (root preferred, then `.claude/`), or pick the
+/// default location to create one.
+fn claude_md_path(root: &Path, scope: &Scope) -> PathBuf {
+    match scope {
+        // Global config conventionally lives at ~/.claude/CLAUDE.md.
+        Scope::Global => root.join(".claude").join("CLAUDE.md"),
+        Scope::Project(_) => {
+            let at_root = root.join("CLAUDE.md");
+            if at_root.exists() {
+                return at_root;
+            }
+            let in_dir = root.join(".claude").join("CLAUDE.md");
+            if in_dir.exists() {
+                return in_dir;
+            }
+            // Neither exists — create at project root (the common convention).
+            at_root
+        }
+    }
+}
+
+fn apply_directives(root: &Path, scope: &Scope) -> Result<()> {
+    let path = claude_md_path(root, scope);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    let updated = upsert_block(&existing, &directives_block());
+
+    if updated == existing {
+        println!("  {} CLAUDE.md already up to date", "•".dimmed());
+        return Ok(());
+    }
+
+    let verb = if existing.is_empty() {
+        "created"
+    } else {
+        "updated"
+    };
+    fs::write(&path, updated)?;
+    println!("  {} {} {}", "✓".green(), verb, path.display());
+    Ok(())
+}
+
+/// Replace the existing marker-delimited Arbor block, or append a fresh one. A
+/// brand-new file gets a `# CLAUDE.md` header before the block.
+fn upsert_block(existing: &str, block: &str) -> String {
+    if let (Some(start), Some(end)) = (existing.find(BEGIN_MARKER), existing.find(END_MARKER)) {
+        let end = end + END_MARKER.len();
+        let mut out = String::with_capacity(existing.len());
+        out.push_str(&existing[..start]);
+        out.push_str(block);
+        out.push_str(&existing[end..]);
+        return out;
+    }
+
+    if existing.is_empty() {
+        return format!("# CLAUDE.md\n\n{block}\n");
+    }
+
+    let mut out = existing.to_string();
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push('\n');
+    out.push_str(block);
+    out.push('\n');
+    out
+}
+
+fn directives_block() -> String {
+    // The arbor guidance mirrors the reference CLAUDE.md, wrapped in markers so
+    // re-running the command updates it in place.
+    format!("{BEGIN_MARKER}\n{GUIDANCE}{END_MARKER}")
+}
+
+const GUIDANCE: &str = r#"## Code Navigation (MANDATORY)
+
+This project is indexed by Arbor. **You MUST use arbor for all codebase exploration.** grep, rg, and find are blocked by hooks and will fail.
+
+### Rules
+
+1. **NEVER use `rg` for anything.** It is blocked. Use `arbor query "term" .` instead.
+2. **NEVER use recursive grep** (`grep -r`, `grep -R`, piped from find). Use `arbor query` or `arbor callers`.
+3. **NEVER use `find . -name`** to discover files. Use `arbor query "pattern" .` or `arbor file-graph "path" .`.
+4. **Allowed grep**: `grep "pattern" /explicit/single/file.java` — only on a specific, known file you've already identified via arbor.
+5. **NEVER Read a file to "explore" it.** Use `arbor file-graph "path" .` first to see structure, THEN Read the specific line range.
+
+### Decision tree
+
+| Intent | Command |
+|--------|---------|
+| "Where is X defined?" | `arbor query "X" . --exclude-test` |
+| "What calls X?" | `arbor callers "X" .` |
+| "What does X call?" | `arbor callees "X" .` |
+| "What's in this file?" | `arbor file-graph "path" .` |
+| "How does A connect to B?" | `arbor path "A" "B" .` |
+| "What changed?" | `arbor diff .` |
+| "Multi-term search" | `arbor query "term1\|term2" . --exclude-test` |
+
+### Project map (auto-injected)
+
+A ranked project skeleton is automatically injected into context on your first tool call each day via a PostToolUse hook. You do NOT need to run it manually — it arrives as output from your first Bash call.
+
+The map shows the most important symbols sorted by PageRank centrality. Entry points are marked with ★. Use it to orient before diving deeper.
+
+To manually re-run with different options:
+```bash
+arbor map . --exclude-test                    # default: 1024 token budget
+arbor map . --exclude-test --tokens 2048      # more detail
+arbor map . --exclude-test --focus "service"  # boost symbols in service layer
+arbor map . --exclude-test --focus-changed    # boost symbols in files you're editing
+```
+
+### Finding symbols
+- `arbor query "name" . --exclude-test` — fuzzy search for symbols (production code only)
+- `arbor query "term1|term2|term3" . --exclude-test` — multi-term OR search (replaces grep with alternation)
+- `arbor inspect "symbol" .` — full detail on one symbol (file, lines, role, centrality, caller/callee counts)
+
+### Understanding relationships
+- `arbor callers "symbol" .` — who calls this? (one hop upstream)
+- `arbor callees "symbol" .` — what does this call? (one hop downstream)
+- `arbor path "start" "end" .` — shortest path between two symbols in the call graph
+
+### Structural views
+- `arbor file-graph "src/path/File.java" .` — all symbols + internal edges within a file
+- `arbor entry-points .` — list HTTP handlers, main functions, webhooks, jobs
+
+### Impact analysis
+- `arbor diff . --json` — blast radius of current git changes
+- `arbor refactor "symbol" .` — blast radius of changing a specific symbol
+
+### All commands support `--json` for structured output.
+
+**Important:** Do NOT redirect stderr with `2>/dev/null` on arbor commands. First-run indexing logs go to stderr — suppressing them makes it look like the command is hanging.
+
+### Workflow
+
+1. **Orient**: `arbor map . --exclude-test` — understand the project structure
+2. **Locate**: `arbor query "name" . --exclude-test` — find specific symbols
+3. **Navigate**: `arbor callers`/`callees`/`path` — trace relationships
+4. **Read**: Only use `Read` AFTER arbor has identified the specific file and line range you need
+
+When `arbor query` returns test files but you need production code, do NOT fall back to grep. Instead:
+1. Pick a symbol from the results (e.g., a test field or builder method)
+2. Run `arbor callers "symbol" .` to trace upstream into production code
+3. Or run `arbor file-graph "src/main/..." .` if you already know the production file path
+
+"#;
+
+// ---------------------------------------------------------------------------
+// .claude/settings.json — hooks + permissions
+// ---------------------------------------------------------------------------
+
+fn settings_path(root: &Path) -> PathBuf {
+    root.join(".claude").join("settings.json")
+}
+
+fn apply_settings(root: &Path) -> Result<()> {
+    let path = settings_path(root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut settings: Value = match fs::read_to_string(&path) {
+        Ok(text) if !text.trim().is_empty() => serde_json::from_str(&text)
+            .map_err(|e| format!("{} is not valid JSON: {e}", path.display()))?,
+        _ => json!({}),
+    };
+
+    if !settings.is_object() {
+        settings = json!({});
+    }
+
+    let hooks_changed = ensure_hooks(&mut settings);
+    let perms_changed = ensure_permissions(&mut settings);
+
+    if !hooks_changed && !perms_changed {
+        println!("  {} settings.json already up to date", "•".dimmed());
+        return Ok(());
+    }
+
+    fs::write(&path, serde_json::to_string_pretty(&settings)? + "\n")?;
+    println!("  {} settings written to {}", "✓".green(), path.display());
+    Ok(())
+}
+
+/// Arbor's three hook commands (bare `arbor`, matching the reference install).
+fn arbor_hook_commands() -> (String, String, String) {
+    // PreToolUse #1: auto-init .arbor/ if an arbor command runs before setup.
+    let init = "echo \"$CLAUDE_TOOL_INPUT\" | grep -q '\\barbor\\b' && \
+[ ! -d .arbor ] && arbor init . >/dev/null 2>&1; exit 0"
+        .to_string();
+    // PreToolUse #2: block rg, recursive grep, and find -name; steer to arbor.
+    let block = "CMD=$(echo \"$CLAUDE_TOOL_INPUT\" | jq -r '.command // .input // .'); \
+echo \"$CMD\" | grep -qE '\\brg\\b' && \
+echo 'BLOCK: Use arbor query \"symbol\" . instead of rg. \
+Multi-term: arbor query \"term1|term2\" . --exclude-test' && exit 1; \
+echo \"$CMD\" | grep -qE '\\bgrep\\b' && \
+echo \"$CMD\" | grep -qE '(-[a-zA-Z]*r|-[a-zA-Z]*R|--recursive|\\*\\*/|\\.\\.?/)' && \
+echo 'BLOCK: Use arbor query/callers/callees instead of recursive grep. \
+Grep on a single known file is OK.' && exit 1; \
+echo \"$CMD\" | grep -qE 'find\\s+\\..*(-name|-type)' && \
+echo 'BLOCK: Use arbor query \"pattern\" . to find files/symbols. \
+Use arbor file-graph for file contents.' && exit 1; exit 0"
+        .to_string();
+    // PostToolUse: inject the project skeleton once per day.
+    let map = "FLAG=\".arbor/.map-injected-$(date +%Y%m%d)\"; \
+[ -f \"$FLAG\" ] && exit 0; touch \"$FLAG\"; \
+echo '--- arbor map (project skeleton) ---'; \
+arbor map . --exclude-test 2>/dev/null; echo '--- end arbor map ---'; exit 0"
+        .to_string();
+    (init, block, map)
+}
+
+/// Insert Arbor hooks into the settings tree. Returns true if anything changed.
+fn ensure_hooks(settings: &mut Value) -> bool {
+    let (init, block, map) = arbor_hook_commands();
+
+    let hooks = settings
+        .as_object_mut()
+        .unwrap()
+        .entry("hooks")
+        .or_insert_with(|| json!({}));
+    if !hooks.is_object() {
+        *hooks = json!({});
+    }
+    let hooks = hooks.as_object_mut().unwrap();
+
+    let pre = add_bash_hooks(hooks, "PreToolUse", &[init, block]);
+    let post = add_bash_hooks(hooks, "PostToolUse", &[map]);
+    pre || post
+}
+
+/// Ensure each command in `cmds` is registered under `event` for the Bash
+/// matcher. Skips commands already present (exact match). Returns true if any
+/// command was added.
+fn add_bash_hooks(
+    hooks: &mut serde_json::Map<String, Value>,
+    event: &str,
+    cmds: &[String],
+) -> bool {
+    let entries = hooks.entry(event.to_string()).or_insert_with(|| json!([]));
+    if !entries.is_array() {
+        *entries = json!([]);
+    }
+    let entries = entries.as_array_mut().unwrap();
+
+    // Which commands are already installed for this event?
+    let existing: Vec<String> = entries
+        .iter()
+        .flat_map(|group| group.get("hooks").and_then(|h| h.as_array()))
+        .flatten()
+        .filter_map(|h| h.get("command").and_then(|c| c.as_str()))
+        .map(String::from)
+        .collect();
+
+    let to_add: Vec<&String> = cmds
+        .iter()
+        .filter(|c| !existing.iter().any(|e| e == *c))
+        .collect();
+
+    if to_add.is_empty() {
+        return false;
+    }
+
+    // Find (or create) the Bash matcher group and append to its hooks array.
+    let group = match entries
+        .iter_mut()
+        .find(|g| g.get("matcher").and_then(|m| m.as_str()) == Some("Bash"))
+    {
+        Some(g) => g,
+        None => {
+            entries.push(json!({ "matcher": "Bash", "hooks": [] }));
+            entries.last_mut().unwrap()
+        }
+    };
+
+    let group_hooks = group.as_object_mut().and_then(|o| {
+        o.entry("hooks".to_string())
+            .or_insert_with(|| json!([]))
+            .as_array_mut()
+    });
+    let Some(group_hooks) = group_hooks else {
+        return false;
+    };
+
+    for cmd in to_add {
+        group_hooks.push(json!({ "type": "command", "command": cmd }));
+    }
+    true
+}
+
+/// Add the arbor command allow-list under `permissions.allow`. Returns true if
+/// any entry was added.
+fn ensure_permissions(settings: &mut Value) -> bool {
+    let perms = settings
+        .as_object_mut()
+        .unwrap()
+        .entry("permissions")
+        .or_insert_with(|| json!({}));
+    if !perms.is_object() {
+        *perms = json!({});
+    }
+    let allow = perms
+        .as_object_mut()
+        .unwrap()
+        .entry("allow")
+        .or_insert_with(|| json!([]));
+    if !allow.is_array() {
+        *allow = json!([]);
+    }
+    let allow = allow.as_array_mut().unwrap();
+
+    let mut changed = false;
+    for entry in PERMISSIONS {
+        let present = allow.iter().any(|v| v.as_str() == Some(*entry));
+        if !present {
+            allow.push(json!(entry));
+            changed = true;
+        }
+    }
+    changed
+}

--- a/crates/arbor-cli/src/hook/mod.rs
+++ b/crates/arbor-cli/src/hook/mod.rs
@@ -1,0 +1,49 @@
+//! `arbor hook <harness>` — install Arbor agent directives + hooks into a
+//! coding-agent harness (CLAUDE.md, settings.json, etc.).
+//!
+//! Built to grow: each harness (claude, opencode, codex, cursor, ...) is a
+//! [`Harness`] implementation. Today only `claude` exists.
+
+use std::path::{Path, PathBuf};
+
+mod claude;
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+/// Where to install directives: a single project, or the user's global config.
+#[derive(Debug, Clone)]
+pub enum Scope {
+    /// Install into a project directory (resolved workspace root).
+    Project(PathBuf),
+    /// Install into the user's home config (e.g. `~/.claude/`).
+    Global,
+}
+
+/// A coding-agent harness Arbor can wire itself into.
+pub trait Harness {
+    /// Apply Arbor directives + hooks for the given scope.
+    fn apply(&self, scope: &Scope) -> Result<()>;
+}
+
+/// Resolve a harness name to its implementation.
+fn lookup(name: &str) -> Option<Box<dyn Harness>> {
+    match name.to_lowercase().as_str() {
+        "claude" => Some(Box::new(claude::Claude)),
+        _ => None,
+    }
+}
+
+/// Entry point for `arbor hook <harness> [path] [--global]`.
+pub fn run(harness: &str, path: &Path, global: bool) -> Result<()> {
+    let Some(h) = lookup(harness) else {
+        return Err(format!("unknown harness '{harness}'. supported: claude").into());
+    };
+
+    let scope = if global {
+        Scope::Global
+    } else {
+        Scope::Project(crate::commands::resolve_project_path(path)?)
+    };
+
+    h.apply(&scope)
+}

--- a/crates/arbor-cli/src/main.rs
+++ b/crates/arbor-cli/src/main.rs
@@ -10,6 +10,7 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod audit;
 mod commands;
+mod hook;
 
 #[derive(Parser)]
 #[command(name = "arbor")]
@@ -399,6 +400,21 @@ enum Commands {
         json: bool,
     },
 
+    /// Install Arbor directives + hooks into a coding-agent harness
+    Hook {
+        /// Harness to wire up (currently: claude)
+        #[arg(default_value = "claude")]
+        harness: String,
+
+        /// Project path to install into (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        /// Install into the user's global config instead of the project
+        #[arg(long)]
+        global: bool,
+    },
+
     /// Output a ranked, token-budgeted skeleton of the codebase
     Map {
         /// Path to analyze (defaults to current directory)
@@ -541,6 +557,11 @@ async fn main() {
             path,
             json,
         } => commands::find_path_cmd(&start, &end, &path, json),
+        Commands::Hook {
+            harness,
+            path,
+            global,
+        } => hook::run(&harness, &path, global),
         Commands::Map {
             path,
             tokens,

--- a/crates/arbor-cli/src/main.rs
+++ b/crates/arbor-cli/src/main.rs
@@ -84,6 +84,10 @@ enum Commands {
         /// Maximum results to return
         #[arg(short, long, default_value = "10")]
         limit: usize,
+
+        /// Exclude test/spec/fixture/mock files from results
+        #[arg(long)]
+        exclude_test: bool,
     },
 
     /// Analyze git changes and preview impact blast radius
@@ -309,6 +313,91 @@ enum Commands {
         #[arg(default_value = ".")]
         path: PathBuf,
     },
+
+    /// Show direct callers of a symbol (who calls this?)
+    Callers {
+        /// The symbol to look up (function name, class name, or qualified path)
+        symbol: String,
+
+        /// Path to analyze (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Show direct callees of a symbol (what does this call?)
+    Callees {
+        /// The symbol to look up
+        symbol: String,
+
+        /// Path to analyze (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// List all detected entry points (HTTP handlers, main, webhooks, jobs, CLI commands)
+    EntryPoints {
+        /// Path to analyze (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Show symbols and call edges within a single file
+    FileGraph {
+        /// Relative path to the file (e.g., 'src/auth.rs')
+        file: String,
+
+        /// Path to analyze (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Show full detail for a single symbol
+    Inspect {
+        /// Name or ID of the symbol
+        symbol: String,
+
+        /// Path to analyze (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Find the shortest path between two symbols in the call graph
+    #[command(name = "path")]
+    FindPath {
+        /// Start symbol (name or ID)
+        start: String,
+
+        /// End symbol (name or ID)
+        end: String,
+
+        /// Path to analyze (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[tokio::main]
@@ -347,7 +436,12 @@ async fn main() {
             no_cache,
             changed_only,
         ),
-        Commands::Query { query, path, limit } => commands::query(&query, limit, &path),
+        Commands::Query {
+            query,
+            path,
+            limit,
+            exclude_test,
+        } => commands::query(&query, limit, &path, exclude_test),
         Commands::Diff {
             path,
             depth,
@@ -405,6 +499,17 @@ async fn main() {
             format,
             path,
         } => commands::audit(&sink, depth, &format, &path),
+        Commands::Callers { symbol, path, json } => commands::callers(&symbol, &path, json),
+        Commands::Callees { symbol, path, json } => commands::callees(&symbol, &path, json),
+        Commands::EntryPoints { path, json } => commands::entry_points(&path, json),
+        Commands::FileGraph { file, path, json } => commands::file_graph(&file, &path, json),
+        Commands::Inspect { symbol, path, json } => commands::inspect(&symbol, &path, json),
+        Commands::FindPath {
+            start,
+            end,
+            path,
+            json,
+        } => commands::find_path_cmd(&start, &end, &path, json),
     };
 
     if let Err(e) = result {

--- a/crates/arbor-cli/src/main.rs
+++ b/crates/arbor-cli/src/main.rs
@@ -398,6 +398,37 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+
+    /// Output a ranked, token-budgeted skeleton of the codebase
+    Map {
+        /// Path to analyze (defaults to current directory)
+        #[arg(default_value = ".")]
+        path: PathBuf,
+
+        /// Token budget (output will not exceed this estimate)
+        #[arg(long, default_value = "1024")]
+        tokens: usize,
+
+        /// Exclude test/spec/fixture/mock files
+        #[arg(long)]
+        exclude_test: bool,
+
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+
+        /// Show full relative paths (disable path compression)
+        #[arg(long)]
+        verbose: bool,
+
+        /// Boost symbols in files changed vs HEAD
+        #[arg(long)]
+        focus_changed: bool,
+
+        /// Boost symbols in files matching this glob pattern (e.g. "*/service/*")
+        #[arg(long)]
+        focus: Option<String>,
+    },
 }
 
 #[tokio::main]
@@ -510,6 +541,23 @@ async fn main() {
             path,
             json,
         } => commands::find_path_cmd(&start, &end, &path, json),
+        Commands::Map {
+            path,
+            tokens,
+            exclude_test,
+            json,
+            verbose,
+            focus_changed,
+            focus,
+        } => commands::map(
+            &path,
+            tokens,
+            exclude_test,
+            json,
+            verbose,
+            focus_changed,
+            focus.as_deref(),
+        ),
     };
 
     if let Err(e) = result {

--- a/crates/arbor-cli/tests/diff_command_integration.rs
+++ b/crates/arbor-cli/tests/diff_command_integration.rs
@@ -41,6 +41,9 @@ fn run_arbor(repo: &Path, args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_arbor"))
         .args(args)
         .current_dir(repo)
+        // These tests run against fresh temp repos with no .arbor/; opt them
+        // into auto-indexing (off by default to avoid mutating other projects).
+        .env("ARBOR_AUTO_INDEX", "1")
         .output()
         .expect("failed to run arbor")
 }
@@ -192,6 +195,7 @@ fn diff_uses_env_commit_range_when_provided() {
         .current_dir(repo)
         .env("ARBOR_DIFF_BASE", &base_sha)
         .env("ARBOR_DIFF_HEAD", &head_sha)
+        .env("ARBOR_AUTO_INDEX", "1")
         .output()
         .expect("failed to run arbor with env range");
 

--- a/crates/arbor-cli/tests/graph_commands_integration.rs
+++ b/crates/arbor-cli/tests/graph_commands_integration.rs
@@ -1,0 +1,343 @@
+use std::fs;
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn run_arbor(dir: &Path, args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_arbor"))
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("failed to run arbor")
+}
+
+fn run_arbor_stdout(dir: &Path, args: &[&str]) -> String {
+    let output = run_arbor(dir, args);
+    assert!(
+        output.status.success(),
+        "arbor {:?} failed:\nstdout: {}\nstderr: {}",
+        args,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).to_string()
+}
+
+#[test]
+fn query_multi_term_or_search() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["query", "helper|multiply", "."]);
+    assert!(
+        stdout.contains("helper") && stdout.contains("multiply"),
+        "expected both 'helper' and 'multiply' in results, got: {stdout}"
+    );
+}
+
+#[test]
+fn query_multi_term_deduplicates() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    // "helper|helper" should not produce duplicates
+    let stdout = run_arbor_stdout(dir, &["query", "helper|helper", "."]);
+    let count = stdout.matches("helper").count();
+    // name appears once in the "Found N matches" line and once in the result
+    assert!(
+        count <= 3,
+        "expected no duplicate results, got {count} occurrences of 'helper': {stdout}"
+    );
+}
+
+#[test]
+fn query_exclude_test_filters_test_files() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    // Add a test file
+    let test_dir = dir.join("tests");
+    std::fs::create_dir_all(&test_dir).expect("create tests dir");
+    std::fs::write(
+        test_dir.join("test_helper.rs"),
+        "fn test_helper_fn() { }\n",
+    )
+    .expect("write test file");
+
+    // Re-index
+    let output = run_arbor(dir, &["index", "."]);
+    assert!(output.status.success());
+
+    let stdout = run_arbor_stdout(dir, &["query", "helper", ".", "--exclude-test"]);
+    assert!(
+        !stdout.contains("test_helper_fn"),
+        "expected test file to be excluded, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("helper"),
+        "expected production 'helper' to remain, got: {stdout}"
+    );
+}
+
+fn setup_rust_project() -> tempfile::TempDir {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let dir = temp.path();
+
+    fs::create_dir_all(dir.join("src")).expect("create src dir");
+    fs::write(
+        dir.join("Cargo.toml"),
+        "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+    )
+    .expect("write Cargo.toml");
+
+    fs::write(
+        dir.join("src").join("main.rs"),
+        r#"fn helper() -> i32 { 42 }
+fn compute(x: i32) -> i32 { helper() + x }
+fn main() { let r = compute(1); println!("{}", r); }
+"#,
+    )
+    .expect("write main.rs");
+
+    fs::write(
+        dir.join("src").join("lib.rs"),
+        r#"pub fn add(a: i32, b: i32) -> i32 { a + b }
+pub fn multiply(a: i32, b: i32) -> i32 { a * b }
+pub fn combined(a: i32, b: i32) -> i32 { add(a, b) + multiply(a, b) }
+"#,
+    )
+    .expect("write lib.rs");
+
+    let output = run_arbor(dir, &["setup", "."]);
+    assert!(
+        output.status.success(),
+        "arbor setup failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    temp
+}
+
+#[test]
+fn callers_finds_direct_callers() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["callers", "helper", "."]);
+    assert!(
+        stdout.contains("compute"),
+        "expected 'compute' to call 'helper', got: {stdout}"
+    );
+}
+
+#[test]
+fn callers_json_output() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["callers", "helper", ".", "--json"]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(json["symbol"], "helper");
+    assert!(json["callers"].as_array().unwrap().len() > 0);
+    assert!(json["callers"][0]["name"].as_str().is_some());
+}
+
+#[test]
+fn callers_not_found_symbol() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let output = run_arbor(dir, &["callers", "nonexistent_xyz", "."]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "expected 'not found' error, got: {stderr}"
+    );
+}
+
+#[test]
+fn callees_finds_direct_callees() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["callees", "compute", "."]);
+    assert!(
+        stdout.contains("helper"),
+        "expected 'compute' to call 'helper', got: {stdout}"
+    );
+}
+
+#[test]
+fn callees_json_output() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["callees", "combined", ".", "--json"]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(json["symbol"], "combined");
+    let callees = json["callees"].as_array().unwrap();
+    let names: Vec<&str> = callees.iter().filter_map(|c| c["name"].as_str()).collect();
+    assert!(names.contains(&"add"), "expected 'add' in callees, got: {names:?}");
+    assert!(
+        names.contains(&"multiply"),
+        "expected 'multiply' in callees, got: {names:?}"
+    );
+}
+
+#[test]
+fn entry_points_finds_main() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["entry-points", "."]);
+    assert!(
+        stdout.contains("main"),
+        "expected 'main' as entry point, got: {stdout}"
+    );
+}
+
+#[test]
+fn entry_points_json_output() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["entry-points", ".", "--json"]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    let eps = json["entry_points"].as_array().unwrap();
+    let names: Vec<&str> = eps.iter().filter_map(|e| e["name"].as_str()).collect();
+    assert!(
+        names.contains(&"main"),
+        "expected 'main' in entry_points, got: {names:?}"
+    );
+}
+
+#[test]
+fn file_graph_shows_symbols_in_file() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["file-graph", "src/lib.rs", "."]);
+    assert!(stdout.contains("add"), "expected 'add' in file graph, got: {stdout}");
+    assert!(
+        stdout.contains("multiply"),
+        "expected 'multiply' in file graph, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("combined"),
+        "expected 'combined' in file graph, got: {stdout}"
+    );
+}
+
+#[test]
+fn file_graph_json_output() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["file-graph", "src/lib.rs", ".", "--json"]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert!(json["file"].as_str().unwrap().contains("lib.rs"));
+    assert!(json["nodes"].as_array().unwrap().len() >= 3);
+    assert!(json["edges"].as_array().is_some());
+}
+
+#[test]
+fn file_graph_not_found() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let output = run_arbor(dir, &["file-graph", "src/nonexistent.rs", "."]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No symbols found"),
+        "expected 'No symbols found' error, got: {stderr}"
+    );
+}
+
+#[test]
+fn inspect_shows_symbol_detail() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["inspect", "main", "."]);
+    assert!(stdout.contains("Name"), "expected Name field, got: {stdout}");
+    assert!(stdout.contains("Kind"), "expected Kind field, got: {stdout}");
+    assert!(stdout.contains("main"), "expected 'main' in output, got: {stdout}");
+}
+
+#[test]
+fn inspect_json_output() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["inspect", "helper", ".", "--json"]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(json["name"], "helper");
+    assert!(json["kind"].as_str().is_some());
+    assert!(json["file"].as_str().is_some());
+    assert!(json["line_start"].as_u64().is_some());
+    assert!(json["centrality"].as_f64().is_some());
+    assert!(json["role"].as_str().is_some());
+    assert!(json["caller_count"].as_u64().is_some());
+    assert!(json["callee_count"].as_u64().is_some());
+    assert!(json["is_entry_point"].is_boolean());
+}
+
+#[test]
+fn inspect_not_found_symbol() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let output = run_arbor(dir, &["inspect", "nonexistent_xyz", "."]);
+    assert!(!output.status.success());
+}
+
+#[test]
+fn path_finds_route_between_symbols() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["path", "main", "helper", "."]);
+    assert!(
+        stdout.contains("main") && stdout.contains("helper"),
+        "expected path from main to helper, got: {stdout}"
+    );
+}
+
+#[test]
+fn path_json_output() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["path", "combined", "add", ".", "--json"]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(json["start"], "combined");
+    assert_eq!(json["end"], "add");
+    assert!(json["path"].as_array().unwrap().len() >= 2);
+    assert!(json["hops"].as_u64().unwrap() >= 1);
+}
+
+#[test]
+fn path_no_route() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    // helper doesn't call main, so no path in that direction
+    let stdout = run_arbor_stdout(dir, &["path", "helper", "main", "."]);
+    assert!(
+        stdout.contains("No path found"),
+        "expected 'No path found', got: {stdout}"
+    );
+}
+
+#[test]
+fn path_no_route_json() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["path", "helper", "main", ".", "--json"]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert!(json["path"].is_null());
+    assert!(json["message"].as_str().unwrap().contains("No path found"));
+}

--- a/crates/arbor-cli/tests/graph_commands_integration.rs
+++ b/crates/arbor-cli/tests/graph_commands_integration.rs
@@ -57,11 +57,8 @@ fn query_exclude_test_filters_test_files() {
     // Add a test file
     let test_dir = dir.join("tests");
     std::fs::create_dir_all(&test_dir).expect("create tests dir");
-    std::fs::write(
-        test_dir.join("test_helper.rs"),
-        "fn test_helper_fn() { }\n",
-    )
-    .expect("write test file");
+    std::fs::write(test_dir.join("test_helper.rs"), "fn test_helper_fn() { }\n")
+        .expect("write test file");
 
     // Re-index
     let output = run_arbor(dir, &["index", "."]);
@@ -138,7 +135,7 @@ fn callers_json_output() {
     let stdout = run_arbor_stdout(dir, &["callers", "helper", ".", "--json"]);
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
     assert_eq!(json["symbol"], "helper");
-    assert!(json["callers"].as_array().unwrap().len() > 0);
+    assert!(!json["callers"].as_array().unwrap().is_empty());
     assert!(json["callers"][0]["name"].as_str().is_some());
 }
 
@@ -178,7 +175,10 @@ fn callees_json_output() {
     assert_eq!(json["symbol"], "combined");
     let callees = json["callees"].as_array().unwrap();
     let names: Vec<&str> = callees.iter().filter_map(|c| c["name"].as_str()).collect();
-    assert!(names.contains(&"add"), "expected 'add' in callees, got: {names:?}");
+    assert!(
+        names.contains(&"add"),
+        "expected 'add' in callees, got: {names:?}"
+    );
     assert!(
         names.contains(&"multiply"),
         "expected 'multiply' in callees, got: {names:?}"
@@ -218,7 +218,10 @@ fn file_graph_shows_symbols_in_file() {
     let dir = temp.path();
 
     let stdout = run_arbor_stdout(dir, &["file-graph", "src/lib.rs", "."]);
-    assert!(stdout.contains("add"), "expected 'add' in file graph, got: {stdout}");
+    assert!(
+        stdout.contains("add"),
+        "expected 'add' in file graph, got: {stdout}"
+    );
     assert!(
         stdout.contains("multiply"),
         "expected 'multiply' in file graph, got: {stdout}"
@@ -261,9 +264,18 @@ fn inspect_shows_symbol_detail() {
     let dir = temp.path();
 
     let stdout = run_arbor_stdout(dir, &["inspect", "main", "."]);
-    assert!(stdout.contains("Name"), "expected Name field, got: {stdout}");
-    assert!(stdout.contains("Kind"), "expected Kind field, got: {stdout}");
-    assert!(stdout.contains("main"), "expected 'main' in output, got: {stdout}");
+    assert!(
+        stdout.contains("Name"),
+        "expected Name field, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("Kind"),
+        "expected Kind field, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("main"),
+        "expected 'main' in output, got: {stdout}"
+    );
 }
 
 #[test]
@@ -340,4 +352,180 @@ fn path_no_route_json() {
     let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
     assert!(json["path"].is_null());
     assert!(json["message"].as_str().unwrap().contains("No path found"));
+}
+
+#[test]
+fn map_default_output() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["map", "."]);
+    assert!(
+        stdout.contains("arbor map"),
+        "expected header with 'arbor map', got: {stdout}"
+    );
+    assert!(
+        stdout.contains("main") || stdout.contains("helper") || stdout.contains("compute"),
+        "expected at least one symbol in output, got: {stdout}"
+    );
+}
+
+#[test]
+fn map_respects_token_budget() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    // With a tiny budget (64 tokens = 256 chars), output should be small
+    let stdout = run_arbor_stdout(dir, &["map", ".", "--tokens", "64"]);
+    // 64 tokens ≈ 256 chars. Output should be short.
+    assert!(
+        stdout.len() < 800,
+        "expected output under 800 chars with 64 token budget, got {} chars",
+        stdout.len()
+    );
+}
+
+#[test]
+fn map_excludes_test_files() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    // Add a test file
+    let test_dir = dir.join("tests");
+    std::fs::create_dir_all(&test_dir).expect("create tests dir");
+    std::fs::write(test_dir.join("test_helper.rs"), "fn test_helper_fn() { }\n")
+        .expect("write test file");
+
+    let output = run_arbor(dir, &["index", "."]);
+    assert!(output.status.success());
+
+    let stdout = run_arbor_stdout(dir, &["map", ".", "--exclude-test"]);
+    assert!(
+        !stdout.contains("test_helper_fn"),
+        "expected test file to be excluded, got: {stdout}"
+    );
+}
+
+#[test]
+fn map_json_output() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["map", ".", "--json"]);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid json");
+    assert_eq!(json["schema"], "arbor.map.v1");
+    assert!(json["symbols_shown"].as_u64().unwrap() > 0);
+    assert!(json["symbols_total"].as_u64().unwrap() > 0);
+    assert!(json["files_shown"].as_u64().unwrap() > 0);
+    assert!(!json["entries"].as_array().unwrap().is_empty());
+
+    let first_file = &json["entries"][0];
+    assert!(first_file["file"].as_str().is_some());
+    assert!(first_file["file_short"].as_str().is_some());
+    assert!(!first_file["symbols"].as_array().unwrap().is_empty());
+
+    let first_sym = &first_file["symbols"][0];
+    assert!(first_sym["name"].as_str().is_some());
+    assert!(first_sym["kind"].as_str().is_some());
+    assert!(first_sym["line"].as_u64().is_some());
+    assert!(first_sym["centrality"].is_number());
+    assert!(first_sym["callers"].is_number());
+    assert!(first_sym["is_entry_point"].is_boolean());
+    assert!(first_sym["signature_short"].as_str().is_some());
+}
+
+#[test]
+fn map_includes_entry_points() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["map", ".", "--tokens", "4096"]);
+    // main() should appear with ★ marker
+    assert!(
+        stdout.contains("main"),
+        "expected 'main' entry point in output, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("★"),
+        "expected ★ entry point marker, got: {stdout}"
+    );
+}
+
+#[test]
+fn map_verbose_shows_full_paths() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    let stdout = run_arbor_stdout(dir, &["map", ".", "--verbose"]);
+    // Verbose should show paths without ... compression
+    // Our test paths are short (src/main.rs) so won't compress anyway,
+    // but at least verify it doesn't crash
+    assert!(
+        stdout.contains("main.rs") || stdout.contains("lib.rs"),
+        "expected file paths in verbose output, got: {stdout}"
+    );
+}
+
+#[test]
+fn map_focus_glob_boosts_matching_files() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    // With a tight budget, --focus on lib.rs should prioritize lib symbols
+    let stdout = run_arbor_stdout(dir, &["map", ".", "--tokens", "128", "--focus", "*/lib*"]);
+    assert!(
+        stdout.contains("add") || stdout.contains("multiply") || stdout.contains("combined"),
+        "expected lib.rs symbols boosted by --focus, got: {stdout}"
+    );
+}
+
+#[test]
+fn map_focus_changed_does_not_crash() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    // Initialize git so --focus-changed can run
+    let _ = std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir)
+        .output();
+    let _ = std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir)
+        .output();
+    let _ = std::process::Command::new("git")
+        .args(["commit", "-m", "init", "--allow-empty"])
+        .current_dir(dir)
+        .output();
+
+    // Should work even with no changes (empty boost set)
+    let stdout = run_arbor_stdout(dir, &["map", ".", "--focus-changed"]);
+    assert!(
+        stdout.contains("arbor map"),
+        "expected valid output with --focus-changed, got: {stdout}"
+    );
+}
+
+#[test]
+fn map_centrality_persists_across_calls() {
+    let temp = setup_rust_project();
+    let dir = temp.path();
+
+    // First call computes centrality and saves it
+    let output1 = run_arbor(dir, &["map", "."]);
+    assert!(output1.status.success());
+    let stderr1 = String::from_utf8_lossy(&output1.stderr);
+    assert!(
+        stderr1.contains("Computing centrality"),
+        "expected first call to compute centrality, got stderr: {stderr1}"
+    );
+
+    // Second call should NOT recompute (loaded from cache)
+    let output2 = run_arbor(dir, &["map", "."]);
+    assert!(output2.status.success());
+    let stderr2 = String::from_utf8_lossy(&output2.stderr);
+    assert!(
+        !stderr2.contains("Computing centrality"),
+        "expected second call to skip centrality computation, got stderr: {stderr2}"
+    );
 }

--- a/crates/arbor-core/src/languages/csharp.rs
+++ b/crates/arbor-core/src/languages/csharp.rs
@@ -455,18 +455,23 @@ fn collect_calls(root: &Node, source: &str, refs: &mut Vec<String>) {
                         }
                     }
                     "member_access_expression" => {
-                        // Only keep this.X / base.X calls to avoid name collision
-                        if let Some(obj) = func.child_by_field_name("expression") {
+                        if let (Some(obj), Some(name_node)) = (
+                            func.child_by_field_name("expression"),
+                            func.child_by_field_name("name"),
+                        ) {
                             let obj_range = obj.byte_range();
-                            if obj_range.end <= source.len() {
+                            let name_range = name_node.byte_range();
+                            if obj_range.end <= source.len() && name_range.end <= source.len() {
                                 let obj_text = &source[obj_range];
+                                let method = &source[name_range];
                                 if obj_text == "this" || obj_text == "base" {
-                                    if let Some(name_node) = func.child_by_field_name("name") {
-                                        let range = name_node.byte_range();
-                                        if range.end <= source.len() {
-                                            refs.push(source[range].to_string());
-                                        }
-                                    }
+                                    // Same-class / parent call — track bare method name.
+                                    refs.push(method.to_string());
+                                } else {
+                                    // `MathUtils.Add` for a static/type-qualified call.
+                                    // Instance calls (`obj.Add`) capture as `obj.Add`, which
+                                    // simply fails to resolve in the builder — no false edge.
+                                    refs.push(format!("{}.{}", obj_text, method));
                                 }
                             }
                         }

--- a/crates/arbor-core/src/languages/java.rs
+++ b/crates/arbor-core/src/languages/java.rs
@@ -399,9 +399,30 @@ fn collect_calls(root: &Node, source: &str, refs: &mut Vec<String>) {
         let node = cursor.node();
         if node.kind() == "method_invocation" {
             if let Some(name_node) = node.child_by_field_name("name") {
-                let range = name_node.byte_range();
-                if range.end <= source.len() {
-                    refs.push(source[range].to_string());
+                let name_range = name_node.byte_range();
+                if name_range.end <= source.len() {
+                    let method = &source[name_range];
+                    // The `object` field is the receiver: `MathUtils` in `MathUtils.add()`.
+                    // Keep it so a static call resolves to the right class FQN (`MathUtils.add`)
+                    // instead of colliding with any same-named method in the repo.
+                    match node.child_by_field_name("object") {
+                        None => refs.push(method.to_string()),
+                        Some(obj) => {
+                            let obj_range = obj.byte_range();
+                            if obj_range.end <= source.len() {
+                                let obj_text = &source[obj_range];
+                                if obj_text == "this" || obj_text == "super" {
+                                    // Same-class / parent call — track bare method name.
+                                    refs.push(method.to_string());
+                                } else {
+                                    // `MathUtils.add` for a static/type-qualified call.
+                                    // Instance calls (`obj.add`) capture as `obj.add`, which
+                                    // simply fails to resolve in the builder — no false edge.
+                                    refs.push(format!("{}.{}", obj_text, method));
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -480,6 +501,40 @@ public interface Greeting {
         assert!(nodes
             .iter()
             .any(|n| n.name == "greet" && matches!(n.kind, NodeKind::Method)));
+    }
+
+    #[test]
+    fn test_static_call_keeps_class_qualifier() {
+        // A static call `MathUtils.add(...)` must be recorded as `MathUtils.add`,
+        // not the bare `add` — otherwise it collides with any same-named method.
+        let source = r#"
+public class Calc {
+    public int compute() {
+        return MathUtils.add(1, 2);
+    }
+    public int self() {
+        return this.helper() + super.base();
+    }
+    private int helper() { return 0; }
+}
+"#;
+        let parser = JavaParser;
+        let mut ts = tree_sitter::Parser::new();
+        ts.set_language(&parser.language()).unwrap();
+        let tree = ts.parse(source, None).unwrap();
+        let nodes = parser.extract_nodes(&tree, source, "Calc.java");
+
+        let compute = nodes.iter().find(|n| n.name == "compute").unwrap();
+        assert!(
+            compute.references.contains(&"MathUtils.add".to_string()),
+            "expected qualified static ref, got {:?}",
+            compute.references
+        );
+
+        let self_method = nodes.iter().find(|n| n.name == "self").unwrap();
+        // this./super. calls strip to the bare method name (same-class / parent resolution)
+        assert!(self_method.references.contains(&"helper".to_string()));
+        assert!(self_method.references.contains(&"base".to_string()));
     }
 
     #[test]

--- a/crates/arbor-graph/src/builder.rs
+++ b/crates/arbor-graph/src/builder.rs
@@ -336,4 +336,31 @@ mod tests {
         assert_eq!(graph.node_count(), 0);
         assert_eq!(graph.edge_count(), 0);
     }
+
+    #[test]
+    fn test_qualified_static_call_resolves_to_correct_class() {
+        // Regression: `MathUtils.add()` in Calc must link to MathUtils.add, NOT to a
+        // same-named `add` on a sibling class. Relies on the parser keeping the class
+        // qualifier so the builder gets an exact FQN match.
+        let mut b = GraphBuilder::new();
+        let caller = CodeNode::new("compute", "Calc.compute", NodeKind::Method, "src/Calc.java")
+            .with_references(vec!["MathUtils.add".to_string()]);
+        // Same-dir sibling with a colliding bare name — the old bug linked here.
+        let sibling = CodeNode::new("add", "Sibling.add", NodeKind::Method, "src/Sibling.java");
+        let target =
+            CodeNode::new("add", "MathUtils.add", NodeKind::Method, "src/util/MathUtils.java");
+        b.add_nodes(vec![caller, sibling, target]);
+        let graph = b.build();
+
+        let compute_idx = graph
+            .node_indexes()
+            .find(|&i| graph.get(i).unwrap().name == "compute")
+            .unwrap();
+        let callees = graph.get_callees(compute_idx);
+        assert_eq!(callees.len(), 1, "exactly one resolved callee");
+        assert_eq!(
+            callees[0].qualified_name, "MathUtils.add",
+            "static call must resolve to the qualified class, not a same-named sibling"
+        );
+    }
 }

--- a/crates/arbor-graph/src/builder.rs
+++ b/crates/arbor-graph/src/builder.rs
@@ -347,8 +347,12 @@ mod tests {
             .with_references(vec!["MathUtils.add".to_string()]);
         // Same-dir sibling with a colliding bare name — the old bug linked here.
         let sibling = CodeNode::new("add", "Sibling.add", NodeKind::Method, "src/Sibling.java");
-        let target =
-            CodeNode::new("add", "MathUtils.add", NodeKind::Method, "src/util/MathUtils.java");
+        let target = CodeNode::new(
+            "add",
+            "MathUtils.add",
+            NodeKind::Method,
+            "src/util/MathUtils.java",
+        );
         b.add_nodes(vec![caller, sibling, target]);
         let graph = b.build();
 

--- a/crates/arbor-graph/src/graph.rs
+++ b/crates/arbor-graph/src/graph.rs
@@ -59,6 +59,17 @@ impl ArborGraph {
         }
     }
 
+    /// Rebuilds the search index from existing graph nodes.
+    /// Call after deserialization since search_index is not serialized.
+    pub fn rebuild_search_index(&mut self) {
+        self.search_index = SearchIndex::new();
+        for index in self.graph.node_indices() {
+            if let Some(node) = self.graph.node_weight(index) {
+                self.search_index.insert(&node.name, index);
+            }
+        }
+    }
+
     /// Adds a code node to the graph.
     ///
     /// Returns the node's index for adding edges later.

--- a/crates/arbor-gui/Cargo.toml
+++ b/crates/arbor-gui/Cargo.toml
@@ -9,9 +9,9 @@ description = "Arbor GUI - Impact-first code analysis interface"
 arbor-core = { path = "../arbor-core", version = "2.0.1" }
 arbor-graph = { path = "../arbor-graph", version = "2.0.1" }
 arbor-watcher = { path = "../arbor-watcher", version = "2.0.1" }
-eframe = "0.28"
-egui = "0.28"
-egui_extras = { version = "0.28", features = ["all_loaders"] }
+eframe = "0.31"
+egui = "0.31"
+egui_extras = { version = "0.31", features = ["all_loaders"] }
 image = { version = "0.25", features = ["jpeg", "png"] } # Required for image loading
 arboard = "3.4"  # Clipboard support
 resvg = "0.44"

--- a/crates/arbor-mcp/src/lib.rs
+++ b/crates/arbor-mcp/src/lib.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::io::{self, BufRead, Write};
 
+use arbor_graph::{compute_centrality, HeuristicsMatcher};
 use arbor_server::{SharedGraph, SyncServerHandle};
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -300,6 +301,19 @@ impl McpServer {
                             "symbol": { "type": "string", "description": "Name or ID of the symbol" }
                         },
                         "required": ["symbol"]
+                    }
+                },
+                {
+                    "name": "get_map",
+                    "description": "Returns a ranked, token-budgeted skeleton of the codebase — the most important symbols ordered by centrality. Use as the FIRST tool call in a session to get a structural overview without reading files. Entry points are marked with ★.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "tokens": { "type": "integer", "description": "Maximum token budget for output (default: 1024)", "default": 1024 },
+                            "exclude_test": { "type": "boolean", "description": "Exclude test/spec/fixture files (default: true)", "default": true },
+                            "focus": { "type": "string", "description": "Boost symbols in files matching this pattern (e.g. 'service', 'pipeline')" }
+                        },
+                        "required": []
                     }
                 }
             ]
@@ -804,12 +818,325 @@ impl McpServer {
                     }
                 }
             }
+            "get_map" => {
+                let token_budget = arguments
+                    .get("tokens")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(1024) as usize;
+                let exclude_test = arguments
+                    .get("exclude_test")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
+                let focus_pattern = arguments
+                    .get("focus")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+
+                let graph = self.graph.read().await;
+
+                // Check if centrality is computed
+                let has_centrality = graph.node_indexes().any(|idx| graph.centrality(idx) > 0.0);
+
+                // If no centrality, we need a mutable graph — drop read, acquire write
+                drop(graph);
+                if !has_centrality {
+                    let mut graph = self.graph.write().await;
+                    let scores = compute_centrality(&graph, 20, 0.85);
+                    graph.set_centrality(scores.into_map());
+                }
+
+                let graph = self.graph.read().await;
+                let result = self.build_map(&graph, token_budget, exclude_test, focus_pattern);
+
+                Ok(Self::ok_envelope(
+                    "get_map",
+                    result,
+                    token_budget,
+                    "search_symbols",
+                    json!({ "query": "" }),
+                ))
+            }
             _ => Err(JsonRpcError {
                 code: -32601,
                 message: format!("Tool not found: {}", name),
                 data: None,
             }),
         }
+    }
+
+    fn build_map(
+        &self,
+        graph: &arbor_graph::ArborGraph,
+        token_budget: usize,
+        exclude_test: bool,
+        focus_pattern: &str,
+    ) -> Value {
+        let max_per_file: usize = if token_budget <= 1024 {
+            5
+        } else if token_budget <= 2048 {
+            8
+        } else {
+            12
+        };
+
+        struct ScoredNode {
+            name: String,
+            kind: String,
+            file: String,
+            line_start: u32,
+            signature: Option<String>,
+            score: f64,
+            is_entry_point: bool,
+            callers: usize,
+        }
+
+        let mut scored: Vec<ScoredNode> = Vec::new();
+        for idx in graph.node_indexes() {
+            let node = match graph.get(idx) {
+                Some(n) => n,
+                None => continue,
+            };
+
+            let kind_str = node.kind.to_string();
+            if kind_str == "import" || kind_str == "export" || kind_str == "module" {
+                continue;
+            }
+
+            if exclude_test && self.is_test_file(&node.file) {
+                continue;
+            }
+
+            if Self::is_minified_or_generated(&node.file) {
+                continue;
+            }
+
+            let centrality = graph.centrality(idx);
+            let is_entry = HeuristicsMatcher::is_likely_entry_point(node);
+            let caller_count = graph.get_callers(idx).len();
+
+            let kind_boost = match kind_str.as_str() {
+                "class" | "interface" | "struct" => 0.1,
+                "constructor" => -0.1,
+                "field" | "constant" => -0.2,
+                _ => 0.0,
+            };
+            let entry_boost = if is_entry { 0.3 } else { 0.0 };
+            let focus_boost = if !focus_pattern.is_empty() && node.file.contains(focus_pattern) {
+                0.3
+            } else {
+                0.0
+            };
+            let score = centrality + entry_boost + kind_boost + focus_boost;
+
+            scored.push(ScoredNode {
+                name: node.name.clone(),
+                kind: kind_str,
+                file: node.file.clone(),
+                line_start: node.line_start,
+                signature: node.signature.clone(),
+                score,
+                is_entry_point: is_entry,
+                callers: caller_count,
+            });
+        }
+
+        scored.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let total_symbols = scored.len();
+
+        // Group by file with per-file cap
+        let mut file_order: Vec<String> = Vec::new();
+        let mut file_groups: std::collections::HashMap<String, Vec<&ScoredNode>> =
+            std::collections::HashMap::new();
+        for node in &scored {
+            let group = file_groups.entry(node.file.clone()).or_default();
+            if group.len() >= max_per_file {
+                continue;
+            }
+            if group.is_empty() {
+                file_order.push(node.file.clone());
+            }
+            group.push(node);
+        }
+
+        // Build JSON entries within budget
+        let budget_chars = token_budget * 4;
+        let mut entries: Vec<Value> = Vec::new();
+        let mut symbols_shown = 0;
+        let mut chars_used = 0;
+
+        for file_path in &file_order {
+            let symbols = match file_groups.get(file_path) {
+                Some(s) => s,
+                None => continue,
+            };
+
+            let mut sym_items: Vec<Value> = Vec::new();
+            for node in symbols {
+                let sig_short = node
+                    .signature
+                    .as_deref()
+                    .map(|s| self.shorten_signature(s))
+                    .unwrap_or_else(|| node.name.clone());
+
+                let item_cost = sig_short.len() + 50;
+                if chars_used + item_cost > budget_chars && symbols_shown > 0 {
+                    break;
+                }
+
+                sym_items.push(json!({
+                    "name": node.name,
+                    "kind": node.kind,
+                    "line": node.line_start,
+                    "centrality": (node.score * 100.0).round() / 100.0,
+                    "callers": node.callers,
+                    "is_entry_point": node.is_entry_point,
+                    "signature_short": sig_short,
+                }));
+                symbols_shown += 1;
+                chars_used += item_cost;
+            }
+
+            if !sym_items.is_empty() {
+                entries.push(json!({
+                    "file": file_path,
+                    "symbols": sym_items,
+                }));
+            }
+
+            if chars_used >= budget_chars {
+                break;
+            }
+        }
+
+        json!({
+            "schema": "arbor.map.v1",
+            "token_estimate": chars_used / 4,
+            "symbols_shown": symbols_shown,
+            "symbols_total": total_symbols,
+            "files_shown": entries.len(),
+            "files_total": file_order.len(),
+            "entries": entries,
+        })
+    }
+
+    fn is_test_file(&self, file_path: &str) -> bool {
+        let lower = file_path.to_lowercase();
+        lower.contains("/test")
+            || lower.contains("/spec")
+            || lower.contains("/fixture")
+            || lower.contains("/mock")
+            || lower.contains("__tests__")
+            || lower.contains(".test.")
+            || lower.contains(".spec.")
+            || lower.contains("_test.")
+    }
+
+    fn is_minified_or_generated(file_path: &str) -> bool {
+        let lower = file_path.to_lowercase();
+        lower.ends_with(".min.js")
+            || lower.ends_with(".min.css")
+            || lower.contains(".chunk.")
+            || lower.contains(".bundle.")
+            || lower.contains("/dist/")
+            || lower.contains("/build/")
+            || lower.contains("/resources/monitor/")
+            || lower.contains("/resources/static/")
+            || lower.contains("/generated/")
+            || {
+                let filename = lower.rsplit('/').next().unwrap_or("");
+                let parts: Vec<&str> = filename.split('.').collect();
+                parts.len() >= 3
+                    && parts[1].len() >= 8
+                    && parts[1].chars().all(|c| c.is_ascii_hexdigit())
+            }
+    }
+
+    fn shorten_signature(&self, sig: &str) -> String {
+        let sig = sig.trim();
+        let paren_start = match sig.find('(') {
+            Some(i) => i,
+            None => {
+                if sig.len() <= 80 {
+                    return sig.to_string();
+                } else {
+                    return format!("{}...", &sig[..77]);
+                }
+            }
+        };
+
+        let before_paren = &sig[..paren_start];
+        let name = before_paren
+            .split_whitespace()
+            .last()
+            .unwrap_or(before_paren)
+            .trim();
+
+        let paren_end = match sig.rfind(')') {
+            Some(i) => i,
+            None => return format!("{}(...)", name),
+        };
+
+        let params_str = &sig[paren_start + 1..paren_end];
+        let param_names = self.extract_param_names(params_str);
+
+        let result = if param_names.is_empty() {
+            format!("{}()", name)
+        } else {
+            format!("{}({})", name, param_names.join(", "))
+        };
+
+        if result.len() > 80 {
+            format!("{}(...)", name)
+        } else {
+            result
+        }
+    }
+
+    fn extract_param_names<'a>(&self, params_str: &'a str) -> Vec<&'a str> {
+        if params_str.trim().is_empty() {
+            return Vec::new();
+        }
+
+        let mut names = Vec::new();
+        let mut depth: i32 = 0;
+        let mut start = 0;
+
+        let bytes = params_str.as_bytes();
+        for i in 0..bytes.len() {
+            match bytes[i] {
+                b'<' | b'(' => depth += 1,
+                b'>' | b')' => depth -= 1,
+                b',' if depth == 0 => {
+                    if let Some(name) = Self::last_word_of_param(&params_str[start..i]) {
+                        names.push(name);
+                    }
+                    start = i + 1;
+                }
+                _ => {}
+            }
+        }
+        if let Some(name) = Self::last_word_of_param(&params_str[start..]) {
+            names.push(name);
+        }
+
+        names
+    }
+
+    fn last_word_of_param(param: &str) -> Option<&str> {
+        let trimmed = param.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if let Some(colon_pos) = trimmed.find(':') {
+            let before_colon = trimmed[..colon_pos].trim();
+            return before_colon.split_whitespace().last();
+        }
+        trimmed.split_whitespace().last()
     }
 
     async fn generate_context(&self, node_start: &str) -> String {
@@ -1008,5 +1335,67 @@ mod tool_tests {
             }))
             .await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_map_returns_envelope() {
+        let server = empty_server();
+        let result = server
+            .call_tool(serde_json::json!({
+                "name": "get_map", "arguments": { "tokens": 1024 }
+            }))
+            .await;
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        let text = val["content"][0]["text"].as_str().unwrap();
+        let envelope: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(envelope["ok"], true);
+        assert_eq!(envelope["tool"], "get_map");
+        assert_eq!(envelope["data"]["schema"], "arbor.map.v1");
+        assert!(envelope["data"]["symbols_total"].is_number());
+        assert!(envelope["data"]["entries"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_get_map_with_populated_graph() {
+        use arbor_core::{CodeNode, NodeKind};
+
+        let graph = ArborGraph::new();
+        let shared: SharedGraph = Arc::new(RwLock::new(graph));
+
+        // Add some nodes
+        {
+            let mut g = shared.write().await;
+            let mut n1 = CodeNode::new("main", "main", NodeKind::Function, "src/main.rs");
+            n1.line_start = 1;
+            n1.line_end = 10;
+            let mut n2 = CodeNode::new("helper", "helper", NodeKind::Function, "src/lib.rs");
+            n2.line_start = 5;
+            n2.line_end = 15;
+            n2.signature = Some("fn helper(x: i32) -> i32".to_string());
+            let idx1 = g.add_node(n1);
+            let idx2 = g.add_node(n2);
+            g.add_edge(
+                idx1,
+                idx2,
+                arbor_graph::Edge::new(arbor_graph::EdgeKind::Calls),
+            );
+        }
+
+        let server = McpServer::new(shared);
+        let result = server
+            .call_tool(serde_json::json!({
+                "name": "get_map", "arguments": { "tokens": 1024, "exclude_test": false }
+            }))
+            .await;
+        assert!(result.is_ok());
+        let val = result.unwrap();
+        let text = val["content"][0]["text"].as_str().unwrap();
+        let envelope: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(envelope["data"]["symbols_total"], 2);
+        assert!(envelope["data"]["symbols_shown"].as_u64().unwrap() >= 2);
+
+        let entries = envelope["data"]["entries"].as_array().unwrap();
+        assert!(!entries.is_empty());
     }
 }

--- a/crates/arbor-mcp/src/lib.rs
+++ b/crates/arbor-mcp/src/lib.rs
@@ -1033,7 +1033,7 @@ impl McpServer {
     }
 
     fn is_test_file(&self, file_path: &str) -> bool {
-        let lower = file_path.to_lowercase();
+        let lower = file_path.to_lowercase().replace('\\', "/");
         lower.contains("/test")
             || lower.contains("/spec")
             || lower.contains("/fixture")
@@ -1045,7 +1045,7 @@ impl McpServer {
     }
 
     fn is_minified_or_generated(file_path: &str) -> bool {
-        let lower = file_path.to_lowercase();
+        let lower = file_path.to_lowercase().replace('\\', "/");
         lower.ends_with(".min.js")
             || lower.ends_with(".min.css")
             || lower.contains(".chunk.")
@@ -1241,7 +1241,12 @@ mod tool_tests {
     fn empty_server() -> McpServer {
         let mut graph = ArborGraph::new();
         // Add a dummy node so the "still indexing" guard passes
-        let node = arbor_core::CodeNode::new("_dummy", "_dummy", arbor_core::NodeKind::Function, "_dummy.rs");
+        let node = arbor_core::CodeNode::new(
+            "_dummy",
+            "_dummy",
+            arbor_core::NodeKind::Function,
+            "_dummy.rs",
+        );
         graph.add_node(node);
         let shared: SharedGraph = Arc::new(RwLock::new(graph));
         McpServer::new(shared)

--- a/crates/arbor-mcp/src/lib.rs
+++ b/crates/arbor-mcp/src/lib.rs
@@ -249,7 +249,7 @@ impl McpServer {
                 },
                 {
                     "name": "get_callers",
-                    "description": "Returns the direct callers of a symbol (one hop upstream). Use to answer 'what calls this function?'",
+                    "description": "Returns the direct callers of a symbol (one hop upstream). Use INSTEAD of grep to find usages/references. Answers 'what calls this function?'",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -271,7 +271,7 @@ impl McpServer {
                 },
                 {
                     "name": "search_symbols",
-                    "description": "Fuzzy-searches symbol names across the graph. Use when you know part of a name but not the full ID.",
+                    "description": "Fuzzy-searches symbol names across the graph. Use INSTEAD of grep/rg/find to locate functions, classes, or files. Supports multi-term OR queries with '|' separator.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -283,7 +283,7 @@ impl McpServer {
                 },
                 {
                     "name": "get_file_graph",
-                    "description": "Returns all symbols and internal call edges within a single file. Use to understand a file's internal structure.",
+                    "description": "Returns all symbols and internal call edges within a single file. Use INSTEAD of reading/catting a file to understand its structure — shows what's defined and how it connects.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -305,7 +305,7 @@ impl McpServer {
                 },
                 {
                     "name": "get_map",
-                    "description": "Returns a ranked, token-budgeted skeleton of the codebase — the most important symbols ordered by centrality. Use as the FIRST tool call in a session to get a structural overview without reading files. Entry points are marked with ★.",
+                    "description": "Returns a ranked, token-budgeted skeleton of the codebase — the most important symbols ordered by centrality. RECOMMENDED FIRST CALL: use this instead of reading files or running find/tree to explore project structure. Entry points are marked with ★.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -331,6 +331,14 @@ impl McpServer {
             })?;
 
         let arguments = params.get("arguments").unwrap_or(&Value::Null);
+
+        // If the graph is empty, the background index hasn't finished yet
+        if self.graph.read().await.node_count() == 0 {
+            return Ok(Self::err_envelope(
+                name,
+                "Arbor is still indexing the project. Please retry in a few seconds.",
+            ));
+        }
 
         match name {
             "get_logic_path" => {
@@ -1231,8 +1239,12 @@ mod tool_tests {
     use tokio::sync::RwLock;
 
     fn empty_server() -> McpServer {
-        let graph: SharedGraph = Arc::new(RwLock::new(ArborGraph::new()));
-        McpServer::new(graph)
+        let mut graph = ArborGraph::new();
+        // Add a dummy node so the "still indexing" guard passes
+        let node = arbor_core::CodeNode::new("_dummy", "_dummy", arbor_core::NodeKind::Function, "_dummy.rs");
+        graph.add_node(node);
+        let shared: SharedGraph = Arc::new(RwLock::new(graph));
+        McpServer::new(shared)
     }
 
     #[tokio::test]

--- a/crates/arbor-server/src/sync_server.rs
+++ b/crates/arbor-server/src/sync_server.rs
@@ -8,7 +8,7 @@
 
 use crate::SharedGraph;
 use arbor_core::ArborParser;
-use arbor_graph::{ArborGraph, Edge, EdgeKind};
+use arbor_graph::{compute_centrality, ArborGraph, Edge, EdgeKind};
 use futures_util::{SinkExt, StreamExt};
 use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashMap;
@@ -696,6 +696,11 @@ async fn run_background_indexer(
                             }
                         }
 
+                        // Recompute centrality so the code map stays in sync with the
+                        // patched graph — new nodes start at 0.0 otherwise and the map drifts.
+                        let scores = compute_centrality(&g, 20, 0.85);
+                        g.set_centrality(scores.into_map());
+
                         let elapsed = start.elapsed();
                         info!(
                             "✅ Indexed {} in {:?} ({} symbols, {} relations)",
@@ -733,6 +738,10 @@ async fn run_background_indexer(
 
                 let mut g = graph.write().await;
                 g.remove_file(&file_str);
+
+                // Recompute centrality so the code map reflects the removed nodes.
+                let scores = compute_centrality(&g, 20, 0.85);
+                g.set_centrality(scores.into_map());
 
                 let update = BroadcastMessage::GraphUpdate(GraphUpdatePayload {
                     is_delta: true,

--- a/crates/arbor-watcher/src/indexer.rs
+++ b/crates/arbor-watcher/src/indexer.rs
@@ -215,6 +215,47 @@ pub fn parse_single_file(path: &Path) -> Result<Vec<CodeNode>, arbor_core::Parse
     parse_file(path)
 }
 
+/// Returns true if any supported source file under `root` is newer than `cache_mtime`.
+///
+/// Used by read commands to detect a stale `graph.bin` before trusting it.
+/// Walks the same gitignore-respecting tree as [`index_directory`] but only
+/// stats files — no parsing — and early-exits on the first newer file.
+///
+/// `cache_mtime` is the modified time of the cache file, in seconds since the
+/// UNIX epoch. Catches edits and additions; a lone deletion leaves no newer
+/// file, so it is picked up on the next edit instead.
+pub fn sources_newer_than(root: &Path, cache_mtime: u64, follow_symlinks: bool) -> bool {
+    let walker = WalkBuilder::new(root)
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .follow_links(follow_symlinks)
+        .build();
+
+    for entry in walker.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.is_dir() {
+            continue;
+        }
+        match path.extension().and_then(|e| e.to_str()) {
+            Some(ext) if arbor_core::languages::is_supported(ext) => {}
+            _ => continue,
+        }
+        let mtime = match std::fs::metadata(path).and_then(|m| m.modified()) {
+            Ok(t) => t
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0),
+            Err(_) => continue,
+        };
+        if mtime > cache_mtime {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,6 +268,27 @@ mod tests {
         let result = index_directory(dir.path(), IndexOptions::default()).unwrap();
         assert_eq!(result.files_indexed, 0);
         assert_eq!(result.nodes_extracted, 0);
+    }
+
+    #[test]
+    fn test_sources_newer_than_detects_fresh_edit() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("a.rs"), "pub fn a() {}").unwrap();
+
+        // Cache mtime far in the past → the source file is newer → stale.
+        assert!(sources_newer_than(dir.path(), 0, false));
+
+        // Cache mtime far in the future → nothing newer → fresh.
+        let far_future = u64::MAX;
+        assert!(!sources_newer_than(dir.path(), far_future, false));
+    }
+
+    #[test]
+    fn test_sources_newer_than_ignores_unsupported_files() {
+        let dir = tempdir().unwrap();
+        // Only an unsupported file exists; it must not mark the cache stale.
+        fs::write(dir.path().join("notes.txt"), "hello").unwrap();
+        assert!(!sources_newer_than(dir.path(), 0, false));
     }
 
     #[test]

--- a/crates/arbor-watcher/src/lib.rs
+++ b/crates/arbor-watcher/src/lib.rs
@@ -10,5 +10,5 @@
 mod indexer;
 mod watcher;
 
-pub use indexer::{index_directory, IndexOptions, IndexResult};
+pub use indexer::{index_directory, sources_newer_than, IndexOptions, IndexResult};
 pub use watcher::{FileChange, FileWatcher};

--- a/docs/assets/CLAUDE-example.md
+++ b/docs/assets/CLAUDE-example.md
@@ -1,0 +1,75 @@
+# CLAUDE.md
+
+## Code Navigation (MANDATORY)
+
+**When scanning any new project for code, first check for a `.arbor/graph.json` file at the project root.** If it exists, the project is indexed by Arbor and you MUST use arbor exclusively for code navigation in that project — do not fall back to grep, rg, find, or reading files to explore.
+
+This project is indexed by Arbor. **You MUST use arbor for all codebase exploration.** grep, rg, and find are blocked by hooks and will fail.
+
+### Rules
+
+1. **NEVER use `rg` for anything.** It is blocked. Use `arbor query "term" .` instead.
+2. **NEVER use recursive grep** (`grep -r`, `grep -R`, piped from find). Use `arbor query` or `arbor callers`.
+3. **NEVER use `find . -name`** to discover files. Use `arbor query "pattern" .` or `arbor file-graph "path" .`.
+4. **Allowed grep**: `grep "pattern" /explicit/single/file.java` — only on a specific, known file you've already identified via arbor.
+5. **NEVER Read a file to "explore" it.** Use `arbor file-graph "path" .` first to see structure, THEN Read the specific line range.
+
+### Decision tree
+
+| Intent | Command |
+|--------|---------|
+| "Where is X defined?" | `arbor query "X" . --exclude-test` |
+| "What calls X?" | `arbor callers "X" .` |
+| "What does X call?" | `arbor callees "X" .` |
+| "What's in this file?" | `arbor file-graph "path" .` |
+| "How does A connect to B?" | `arbor path "A" "B" .` |
+| "What changed?" | `arbor diff .` |
+| "Multi-term search" | `arbor query "term1\|term2" . --exclude-test` |
+
+### Project map (auto-injected)
+
+A ranked project skeleton is automatically injected into context on your first tool call each day via a PostToolUse hook. You do NOT need to run it manually — it arrives as output from your first Bash call.
+
+The map shows the most important symbols sorted by PageRank centrality. Entry points are marked with ★. Use it to orient before diving deeper.
+
+To manually re-run with different options:
+```bash
+arbor map . --exclude-test                    # default: 1024 token budget
+arbor map . --exclude-test --tokens 2048      # more detail
+arbor map . --exclude-test --focus "service"  # boost symbols in service layer
+arbor map . --exclude-test --focus-changed    # boost symbols in files you're editing
+```
+
+### Finding symbols
+- `arbor query "name" . --exclude-test` — fuzzy search for symbols (production code only)
+- `arbor query "term1|term2|term3" . --exclude-test` — multi-term OR search (replaces grep with alternation)
+- `arbor inspect "symbol" .` — full detail on one symbol (file, lines, role, centrality, caller/callee counts)
+
+### Understanding relationships
+- `arbor callers "symbol" .` — who calls this? (one hop upstream)
+- `arbor callees "symbol" .` — what does this call? (one hop downstream)
+- `arbor path "start" "end" .` — shortest path between two symbols in the call graph
+
+### Structural views
+- `arbor file-graph "src/path/File.java" .` — all symbols + internal edges within a file
+- `arbor entry-points .` — list HTTP handlers, main functions, webhooks, jobs
+
+### Impact analysis
+- `arbor diff . --json` — blast radius of current git changes
+- `arbor refactor "symbol" .` — blast radius of changing a specific symbol
+
+### All commands support `--json` for structured output.
+
+**Important:** Do NOT redirect stderr with `2>/dev/null` on arbor commands. First-run indexing logs go to stderr — suppressing them makes it look like the command is hanging.
+
+### Workflow
+
+1. **Orient**: `arbor map . --exclude-test` — understand the project structure
+2. **Locate**: `arbor query "name" . --exclude-test` — find specific symbols
+3. **Navigate**: `arbor callers`/`callees`/`path` — trace relationships
+4. **Read**: Only use `Read` AFTER arbor has identified the specific file and line range you need
+
+When `arbor query` returns test files but you need production code, do NOT fall back to grep. Instead:
+1. Pick a symbol from the results (e.g., a test field or builder method)
+2. Run `arbor callers "symbol" .` to trace upstream into production code
+3. Or run `arbor file-graph "src/main/..." .` if you already know the production file path


### PR DESCRIPTION
## Description

This PR brings the CLI to parity with the MCP tool surface, adds a token-budgeted `map` command, includes several concurrency and indexing fixes, and adds a new `arbor hook` command that wires arbor into a coding-agent harness (Claude Code) in one shot. The CLI can now perform most operations previously available only to AI agents through the MCP bridge — graph queries, caller/callee lookups, symbol inspection, and path traversal — directly from the terminal. It also fixes a parser bug where Java and C# static method calls were mapped to the wrong target (or dropped).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Performance improvement
- [x] Code refactoring

## Changes Made

- **`map` command** (`commands.rs`, `main.rs`): Produces a ranked, token-budgeted project skeleton using PageRank and entry-point detection. Supports `--tokens N`, `--focus`, `--focus-changed`, `--json`, and `--verbose`. Centrality scores are persisted to the cache so repeat invocations skip recomputation.
- **CLI/MCP parity**: Adds `callers`, `callees`, `entry-points`, `file-graph`, `inspect`, and `path` commands matching the existing MCP tools. All support `--json`.
- **Multi-term query**: `query "a|b" .` performs OR search with test-file filtering.
- **MCP `get_map` tool** (`arbor-mcp/src/lib.rs`): Exposes the map output to agents as well.
- **`arbor hook claude`** (`arbor-cli/src/hook/`): New `arbor hook <harness> [path] [--global]` command installs arbor agent directives + hooks into a coding-agent harness in one shot. Claude is the lone impl; a `Harness` trait + dispatch leave room for opencode/codex/etc.
  - **CLAUDE.md**: upserts a marker-delimited arbor guidance block (root `CLAUDE.md` preferred, then `.claude/`, else creates root). Re-run replaces the block in place — never duplicates.
  - **`.claude/settings.json`**: adds the 3 Bash hooks (auto-init, block recursive grep/find, daily map inject) plus arbor command `permissions.allow`. Dedups by exact match, preserves existing user content.
  - **`--global`** targets `~/.claude/`. Hooks, permissions, and guidance match the documented reference install byte-for-byte.
- **Static method call mapping fix** (`arbor-core/src/languages/java.rs`, `csharp.rs`): Qualified static calls like `MathUtils.add()` were captured by the Java parser as the bare method name `add`, dropping the class qualifier. The builder then resolved that bare name by suffix-matching, so the edge was either dropped (ambiguous name) or linked to the **wrong class** (a same-named method in a sibling file). C# dropped static calls entirely. Both parsers now keep the receiver (`MathUtils.add`), which exact-matches the stored FQN in the builder and links to the correct class. `this.`/`super.`/`base.` calls still strip to the bare name for same-class resolution, and instance calls (`obj.method`) keep `obj.method` and fail safe (no false edge). This matches the behavior Go/C++/Rust/Python already had.
- **Concurrency fixes**: Single-writer persist lock, atomic cache writes (`.tmp` plus rename), cache staleness check, and sled lock avoidance when a bridge may hold the exclusive lock.
- **Incremental code map updates** (`arbor-watcher/src/indexer.rs`): Re-parses only changed files.
- **`auto_index` gate**: Indexing of un-indexed projects is now gated behind the `auto_index` config option (default off) to avoid unexpected indexing.
- **Docs**: Updated the agent integration section in `CLAUDE.md` and added `docs/assets/CLAUDE-example.md`.

## Known Limitations

- **Dart call edges**: While auditing static-call handling, I found the Dart parser's `collect_calls` looks for a `call_expression` node that the tree-sitter-dart grammar never emits (it uses `member_access` + `selector`), so Dart currently captures **zero** call edges. This is a pre-existing, separate bug and is left for a follow-up rewrite — not addressed here.

## Testing

- [x] Ran `cargo test --all`
- [x] Ran `cargo clippy --all`
- [ ] Ran `flutter test` (not applicable — no visualizer changes)
- [x] Tested manually with a real codebase

Added integration coverage in `graph_commands_integration.rs` (531 lines) for the new query commands. Added regression tests for the static-call fix: parser-level (Java keeps the qualifier; `this.`/`super.` strip to bare name) and a builder end-to-end test proving a qualified static call resolves to the correct class instead of a same-named sibling.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have added tests for my changes
- [x] I have updated the documentation where necessary
- [x] All new and existing tests pass
- [x] I have added appropriate comments where the code isn't self-explanatory

> Note: `CHANGELOG.md` has not yet been updated for these user-facing changes; `[Unreleased]` entries can be added if desired. The branch can be squashed before merge if preferred.
