### PR TITLE
docs: replace hero GIF with grep-vs-arbor side-by-side demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@
   <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="MIT License" />
 </p>
 
+<p align="center">
+  <img src="docs/assets/arbor-demo.gif" alt="Side-by-side: an agent navigating tokio with grep-and-read (47 tool calls, still searching) vs the same agent with arbor's code graph (4 graph calls + 1 read, done)" width="900" />
+</p>
+<p align="center">
+  <sub>Simulated replay — the <code>arbor</code> commands and their output are real (tokio @ 178k LOC). Methodology: <a href="docs/BENCHMARKS.md">BENCHMARKS.md</a></sub>
+</p>
+
 > **v2.5.0 — The Last Excuse** · PageRank **23x faster** (149.8ms → 6.6ms on a 10k-node graph). Indexing goes parallel across every core. A 178k-LOC codebase cold-indexes in **1.6s**. "Indexing is slow" was the last argument for letting your agent navigate with `grep -r` — it's gone. Every number reproducible: [BENCHMARKS.md](docs/BENCHMARKS.md) · [Release notes →](docs/RELEASE_NOTES_v2.5.0.md)
 
 ---
@@ -158,10 +165,6 @@ All query commands support `--json`. `map` additionally supports `--tokens N`, `
 ---
 
 ## Visual tour
-
-<p align="center">
-  <img src="docs/assets/arbor-demo.gif" alt="Arbor demo animation" width="760" />
-</p>
 
 <p align="center">
   <img src="docs/assets/visualizer-screenshot.png" alt="Arbor visualizer screenshot" width="760" />


### PR DESCRIPTION
New top-fold demo: same bug in tokio (178k LOC), grep-and-read agent (47 calls, still searching) vs arbor graph navigation (4 graph calls + 1 read, done). Simulated replay with real arbor commands and output; disclosure caption under the embed. Replaces the old hero GIF and its duplicate embed in the visual tour.

## Description

Brief description of what this PR does. Link any related issues.

Fixes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Changes Made

- List the key changes made in this PR
- Be specific about files/modules affected

## Testing

Describe how you tested your changes:

- [ ] Ran `cargo test --all`
- [ ] Ran `cargo clippy --all`
- [ ] Ran `flutter test` (if applicable)
- [ ] Tested manually with a real codebase

## Screenshots (if applicable)

For visualizer changes, include before/after screenshots.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes
- [ ] I have updated the documentation where necessary
- [ ] All new and existing tests pass
- [ ] I have added appropriate comments where the code isn't self-explanatory
