### PR TITLE
fix(release): sync remaining manifests to 2.5.0 + hero GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@
   <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="MIT License" />
 </p>
 
+<p align="center">
+  <img src="docs/assets/arbor-demo.gif" alt="Side-by-side: an agent navigating tokio with grep-and-read (47 tool calls, still searching) vs the same agent with arbor's code graph (4 graph calls + 1 read, done)" width="900" />
+</p>
+<p align="center">
+  <sub>Simulated replay — the <code>arbor</code> commands and their output are real (tokio @ 178k LOC). Methodology: <a href="docs/BENCHMARKS.md">BENCHMARKS.md</a></sub>
+</p>
+
 > **v2.5.0 — The Last Excuse** · PageRank **23x faster** (149.8ms → 6.6ms on a 10k-node graph). Indexing goes parallel across every core. A 178k-LOC codebase cold-indexes in **1.6s**. "Indexing is slow" was the last argument for letting your agent navigate with `grep -r` — it's gone. Every number reproducible: [BENCHMARKS.md](docs/BENCHMARKS.md) · [Release notes →](docs/RELEASE_NOTES_v2.5.0.md)
 
 ---
@@ -158,10 +165,6 @@ All query commands support `--json`. `map` additionally supports `--tokens N`, `
 ---
 
 ## Visual tour
-
-<p align="center">
-  <img src="docs/assets/arbor-demo.gif" alt="Arbor demo animation" width="760" />
-</p>
 
 <p align="center">
   <img src="docs/assets/visualizer-screenshot.png" alt="Arbor visualizer screenshot" width="760" />

--- a/agent-card.json
+++ b/agent-card.json
@@ -1,7 +1,7 @@
 {
   "name": "Arbor Code Intelligence",
   "description": "Graph-native code intelligence — blast radius analysis, impact prediction, architecture mapping, and security audit tracing for AI coding agents.",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "url": "https://github.com/Anandb71/arbor",
   "capabilities": {
     "tools": true,

--- a/packaging/homebrew/arbor.rb
+++ b/packaging/homebrew/arbor.rb
@@ -4,7 +4,7 @@ class Arbor < Formula
   desc "Graph-native intelligence for codebases — know what breaks before you break it"
   homepage "https://github.com/Anandb71/arbor"
   license "MIT"
-  version "2.4.0"
+  version "2.5.0"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/packaging/scoop/arbor.json
+++ b/packaging/scoop/arbor.json
@@ -1,11 +1,11 @@
 {
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Graph-native intelligence for codebases — know what breaks before you break it",
   "homepage": "https://github.com/Anandb71/arbor",
   "license": "MIT",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/Anandb71/arbor/releases/download/v2.4.0/arbor-windows-x86_64.zip",
+      "url": "https://github.com/Anandb71/arbor/releases/download/v2.5.0/arbor-windows-x86_64.zip",
       "hash": "9db27c25af953727b001bcd77bd27b08677204a169717d6912dafd0090e32654",
       "bin": "arbor.exe"
     }


### PR DESCRIPTION
Unblocks the failed v2.5.0 Release run (29430318624).

**Why it failed:** the release workflow's version-sync gate checks `packaging/scoop/arbor.json`, `packaging/homebrew/arbor.rb`, and `agent-card.json` in addition to the cargo/npm/vscode manifests — those three were missed in the 2.5.0 bump (same first-run failure v2.4.0 had).

**This PR:**
- bumps all three to 2.5.0 (binary checksums get refreshed after release assets exist, same as v2.4.0's flow)
- cherry-picks the hero demo GIF commit, which landed on `feat/v2.5.0-perf` after the merge and never reached main

**After merging:** the v2.5.0 tag must be re-pointed at the new main head to rerun the Release workflow — say the word and I'll do it, or:
```
git fetch && git tag -f v2.5.0 origin/main && git push -f origin v2.5.0
```